### PR TITLE
Sync upstream v0.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.20] - 2025-11-20
+
+### Improvements
+
+- Improved data type handling for DataRobot connections.
+- Unrolled templated prompts for ease of editing.
+
 ## [0.3.19] - 2025-11-11
 
 ### Added

--- a/app_backend/pyproject.toml
+++ b/app_backend/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "pydantic==2.7.4,<3.0",
     "pydantic-settings==2.4.0,<3.0",
     "python-dotenv>=1.0.1",
+    "python-docx>=1.1.0,<2.0",
     "python-multipart>=0.0.20,<1.0",
     "scikit-learn>=1.6.1,<2.0",
     "scipy>=1.15.1,<2.0",

--- a/app_backend/tests/test_main.py
+++ b/app_backend/tests/test_main.py
@@ -38,6 +38,18 @@ def test_reports_spa_routes() -> None:
         assert response.headers["content-type"] == "text/html; charset=utf-8"
 
 
+def test_customize_api_routes_are_mounted() -> None:
+    paths = {
+        getattr(route, "path", "")
+        for route in app.routes
+        if getattr(route, "path", "").startswith("/api/v1")
+    }
+
+    assert "/api/v1/config/feature-flags" in paths
+    assert "/api/v1/refiner" in paths
+    assert "/api/v1/reports" in paths
+
+
 def test_favicon_file() -> None:
     response = client.get("/datarobot_favicon.png")
     assert response.status_code == 200

--- a/customize_docs/upstream_sync_plan.md
+++ b/customize_docs/upstream_sync_plan.md
@@ -36,9 +36,8 @@
 
 | タグ | ブランチ | 判断 | 主な差分 | 競合/注意点 | テスト |
 | --- | --- | --- | --- | --- | --- |
-| `v0.3.20` | `codex/upstream-sync-v0.3.20` | 取り込む | `utils/analyst_db.py`, `utils/api.py`, `utils/datarobot_dataset_handler.py`, `utils/prompts.py` | `CHANGELOG.md` のみ競合。内容を両方残す方針で解消する。 | 実行予定 |
+| `v0.3.20` | `codex/upstream-sync-v0.3.20` | 取り込む | `utils/analyst_db.py`, `utils/api.py`, `utils/datarobot_dataset_handler.py`, `utils/prompts.py` | `CHANGELOG.md` のみ競合。内容を両方残して解消済み。カスタムAPIのcharacterization test追加時に `python-docx` が `app_backend/pyproject.toml` に不足していることを検知し、依存関係を追加。 | `uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py`: 16 passed, 2 skipped |
 | `v0.3.21` | 未作成 | 取り込む候補 | `.env.template`, `README.md`, i18n, `utils/api.py`, `utils/rest_api.py`, dataset handling | 読み取り専用マージでは `CHANGELOG.md` のみ競合。README/env/API差分は確認してからPR化する。 | 未実行 |
 | `v0.3.22` | 未作成 | 取り込む候補 | frontend select UI, `utils/base_telemetry.py` | 読み取り専用マージでは `CHANGELOG.md` のみ競合。UI差分のためfrontend検証を追加する。 | 未実行 |
 | `v0.3.23` | 未作成 | 取り込む候補 | `infra/__main__.py`, `requirements.txt`, dataset handling | 読み取り専用マージでは `CHANGELOG.md` のみ競合。infra差分はPulumi設定への影響を確認する。 | 未実行 |
 | `v0.4.24` 以降 | 未作成 | 別判断 | 大きな構成変更を含む可能性 | `utils -> core/src/core` の移植判断が必要。専用PRで扱う。 | 未実行 |
-

--- a/utils/prompts.py
+++ b/utils/prompts.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import abc
 
-from jinja2 import Environment
 
 SYSTEM_PROMPT_GET_DICTIONARY = """
 YOUR ROLE:
@@ -559,26 +557,9 @@ If this happens, you will be provided the failed query and the error message.
 Take this failed SQL code and error message into consideration when building your query so that the problem doesn't happen again.
 """
 
-
-def sql_prompt_template(
-    *,
-    language_variant: str,
-    base_language: str,
-    execution_environment: str,
-    table_context: dict[str, str],
-    extra_necessary_considerations: str,
-    prohibited_commands_example: str,
-    varchar_categorical: str,
-    where: str,
-    group_by: str,
-) -> str:
-    sql_variant = f"{language_variant} {base_language}"
-    return (
-        Environment()
-        .from_string(
-            """
+SYSTEM_PROMPT_SPARK_SQL = """
 ROLE:
-Your job is to write a {{sql_variant}} query that analyzes one or more tables.
+Your job is to write a Spark SQL query that analyzes one or more tables.
 The query will be executed against these tables, performing the necessary calculations and aggregations required to answer the user's business question.
 Carefully inspect the information and metadata provided to ensure your query will execute and return data.
 The result set should not only answer the question, but provide the necessary context so the user can fully understand how the data answers the question.
@@ -587,191 +568,78 @@ For example, if the user asks, "Which State has the highest revenue?" Your query
 CONTEXT:
 You will be provided a data dictionary for the tables that identifies the data type and meaning of each column.
 You will also be provided a small sample of data from the table. This will help you understand the content of the columns as you build your query reducing the risk of errors.
-You will also be provided a list of frequently occurring values from {{varchar_categorical}} columns. This will be helpful when adding {{where}} clauses in your query.
+You will also be provided a list of frequently occurring values from VARCHAR / categorical columns. This will be helpful when adding WHERE clauses in your query.
 Based on this metadata, build your query so that it will run without error and return data.
 Your query should return not just the facts directly related to the question, but also return related information that could be part of the root cause or provide additional analytics value.
-Your query will be executed with {{sql_variant}}.
+Your query will be executed with Spark SQL.
 
 RESPONSE:
-Your response shall be a single, executable {{sql_variant}} query that retrieves, analyzes, aggregates and returns the information required to answer the user's question.
+Your response shall be a single, executable Spark SQL query that retrieves, analyzes, aggregates and returns the information required to answer the user's question.
 In addition, your response should return any relevant, supporting or contextual information to help the user better understand the results.
 Try to ensure that your query does not return an empty result set.
 Your code may not include any operations that could alter or corrupt the data.
-You may not use {{prohibited_commands_example}} or anything that could permanently alter the data.
+You may not use DELETE, UPDATE, TRUNCATE, DROP, DML Operations, ALTER TABLE or anything that could permanently alter the data.
 Your code should be robust against errors, with a high likelihood of successfully executing.
-The dataset may contain very large amounts of data. Your query result must not be excessively lengthy, therefore consider appropriate {{group_by}} clauses and aggregations.
+The dataset may contain very large amounts of data. Your query result must not be excessively lengthy, therefore consider appropriate GROUP BY clauses and aggregations.
 The result of this query will be analyzed by humans and plotted in charts, so consider appropriate ways to organize and sort the data so that it is easy to interpret.
 Do not provide multiple queries that must be executed in different steps – the query must execute in a single step.
 Include comments to explain your code.
 Your response shall be formatted as JSON with the following fields:
-1) code: {{sql_variant}} code that will execute and return the data
+1) code: Spark SQL code that will execute and return the data
 2) description: A brief description of how the code works, and how the results can be interpreted to answer the question.
-{% if table_context %}
-{{execution_environment.upper()}} ENVIRONMENT:
-{% for k, v in table_context.items() %}
-{{k}}: {{v}}
-{% endfor %}
-{% endif %}
+
 NECESSARY CONSIDERATIONS:
 Carefully consider the metadata and the sample data when constructing your query to avoid errors or an empty result.
 For example, seemingly numeric columns might contain non-numeric formatting such as $1,234.91 which could require special handling.
-This query will be executed using {{execution_environment}}.
-Use standard {{sql_variant}} syntax and functions.
-{{extra_necessary_considerations}}
-
-LANGUAGE:
-Any natural-language text in your response (e.g., the "description") must be in the same language as the user's question. If the language cannot be determined, default to English. {{base_language}} remains {{base_language}}.
-
-REATTEMPT:
-It's possible that your query will fail due to a {{base_language}} error or return an empty result set.
-If this happens, you will be provided the failed query and the error message.
-Take this failed {{base_language}} code and error message into consideration when building your query so that the problem doesn't happen again.
-"""
-        )
-        .render(locals())
-        .strip()
-    )
-
-
-class QueryPromptFactory(abc.ABC):
-    @property
-    @abc.abstractmethod
-    def language_variant(self) -> str:
-        pass
-
-    @property
-    def base_language(self) -> str:
-        return "SQL"
-
-    @property
-    @abc.abstractmethod
-    def execution_environment(self) -> str:
-        pass
-
-    @property
-    def extra_necessary_considerations(self) -> str:
-        return ""
-
-    @property
-    def prohibited_commands_example(self) -> str:
-        return "DELETE, UPDATE, TRUNCATE, DROP, DML Operations, ALTER TABLE"
-
-    @property
-    def varchar_categorical(self) -> str:
-        return "VARCHAR / categorical"
-
-    @property
-    def where(self) -> str:
-        return "WHERE"
-
-    @property
-    def group_by(self) -> str:
-        return "GROUP BY"
-
-    @abc.abstractmethod
-    def adapt_datasource_to_table_context(
-        self,
-        *,
-        catalog: str | None = None,
-        schema: str | None = None,
-    ) -> dict[str, str]:
-        pass
-
-    def prompt_for_datasource(
-        self,
-        *,
-        catalog: str | None = None,
-        schema: str | None = None,
-    ) -> str:
-        return sql_prompt_template(
-            language_variant=self.language_variant,
-            base_language=self.base_language,
-            execution_environment=self.execution_environment,
-            table_context=self.adapt_datasource_to_table_context(
-                catalog=catalog, schema=schema
-            ),
-            extra_necessary_considerations=self.extra_necessary_considerations,
-            prohibited_commands_example=self.prohibited_commands_example,
-            where=self.where,
-            varchar_categorical=self.varchar_categorical,
-            group_by=self.group_by,
-        )
-
-    def adapt_table_path(self, path: str) -> str:
-        return path
-
-
-class SparkPromptFactory(QueryPromptFactory):
-    @property
-    def language_variant(self) -> str:
-        return "Spark"
-
-    @property
-    def execution_environment(self) -> str:
-        return "Spark SQL"
-
-    @property
-    def extra_necessary_considerations(self) -> str:
-        return """
+This query will be executed using Spark SQL.
+Use standard Spark SQL syntax and functions.
 When performing date operations on a date column, consider using appropriate Spark SQL date functions for error redundancy.
 Table references will be provided already properly quoted in backticks.
+
+LANGUAGE:
+Any natural-language text in your response (e.g., the "description") must be in the same language as the user's question. If the language cannot be determined, default to English. SQL remains SQL.
+
+REATTEMPT:
+It's possible that your query will fail due to a SQL error or return an empty result set.
+If this happens, you will be provided the failed query and the error message.
+Take this failed SQL code and error message into consideration when building your query so that the problem doesn't happen again.
 """.strip()
 
-    def adapt_table_path(self, path: str) -> str:
-        return f"`{path}`"
+SYSTEM_PROMPT_REDSHIFT = """
+Your job is to write a Redshift SQL query that analyzes one or more tables.
+The query will be executed against these tables, performing the necessary calculations and aggregations required to answer the user's business question.
+Carefully inspect the information and metadata provided to ensure your query will execute and return data.
+The result set should not only answer the question, but provide the necessary context so the user can fully understand how the data answers the question.
+For example, if the user asks, "Which State has the highest revenue?" Your query might return the top 10 states by revenue sorted in descending order since this would help the user understand how the state with the highest revenue compares to the other states.
 
-    def adapt_datasource_to_table_context(
-        self, *, catalog: str | None = None, schema: str | None = None
-    ) -> dict[str, str]:
-        if catalog or schema:
-            raise ValueError("Catalog/Schema not supported for Spark.")
-        return {}
+CONTEXT:
+You will be provided a data dictionary for the tables that identifies the data type and meaning of each column.
+You will also be provided a small sample of data from the table. This will help you understand the content of the columns as you build your query reducing the risk of errors.
+You will also be provided a list of frequently occurring values from VARCHAR / categorical columns. This will be helpful when adding WHERE clauses in your query.
+Based on this metadata, build your query so that it will run without error and return data.
+Your query should return not just the facts directly related to the question, but also return related information that could be part of the root cause or provide additional analytics value.
+Your query will be executed with Redshift SQL.
 
+RESPONSE:
+Your response shall be a single, executable Redshift SQL query that retrieves, analyzes, aggregates and returns the information required to answer the user's question.
+In addition, your response should return any relevant, supporting or contextual information to help the user better understand the results.
+Try to ensure that your query does not return an empty result set.
+Your code may not include any operations that could alter or corrupt the data.
+You may not use DELETE, UPDATE, TRUNCATE, DROP, DML Operations, ALTER TABLE or anything that could permanently alter the data.
+Your code should be robust against errors, with a high likelihood of successfully executing.
+The dataset may contain very large amounts of data. Your query result must not be excessively lengthy, therefore consider appropriate GROUP BY clauses and aggregations.
+The result of this query will be analyzed by humans and plotted in charts, so consider appropriate ways to organize and sort the data so that it is easy to interpret.
+Do not provide multiple queries that must be executed in different steps – the query must execute in a single step.
+Include comments to explain your code.
+Your response shall be formatted as JSON with the following fields:
+1) code: Redshift SQL code that will execute and return the data
+2) description: A brief description of how the code works, and how the results can be interpreted to answer the question.
 
-class PostgresPromptFactory(QueryPromptFactory):
-    @property
-    def language_variant(self) -> str:
-        return "Postgres"
-
-    @property
-    def execution_environment(self) -> str:
-        return "PostgreSQL"
-
-    @property
-    def extra_necessary_considerations(self) -> str:
-        return """
-When performing date operations on a date column, consider using appropriate PostgreSQL date functions for error redundancy.
-The table name will be provided in fully quoted form, with catalog and schema (if present). No need to add quotes.
-""".strip()
-
-    def adapt_datasource_to_table_context(
-        self, *, catalog: str | None = None, schema: str | None = None
-    ) -> dict[str, str]:
-        context = {}
-        if catalog:
-            context["Catalog"] = catalog
-        if schema:
-            context["Schema"] = schema
-        return context
-
-    def adapt_table_path(self, path: str) -> str:
-        return ".".join(f'"{part}"' for part in path.split("."))
-
-
-class RedshiftPromptFactory(PostgresPromptFactory):
-    @property
-    def language_variant(self) -> str:
-        return "Redshift (PostgreSQL)"
-
-    @property
-    def execution_environment(self) -> str:
-        return "Redshift"
-
-    @property
-    def extra_necessary_considerations(self) -> str:
-        # See https://docs.aws.amazon.com/redshift/latest/dg/c_redshift-and-postgres-sql.html
-        # In order to not bloat the prompt, I'm not listing every difference below, just some  key ones.
-        return """
+NECESSARY CONSIDERATIONS:
+Carefully consider the metadata and the sample data when constructing your query to avoid errors or an empty result.
+For example, seemingly numeric columns might contain non-numeric formatting such as $1,234.91 which could require special handling.
+This query will be executed using Redshift.
+Use standard Redshift SQL syntax and functions.
 When performing date operations on a date column, consider using appropriate Redshift date functions for error redundancy.
 The table name will be provided in fully quoted form, with catalog and schema (if present). No need to add quotes.
 
@@ -782,14 +650,59 @@ Do NOT attempt to use any of the following functions unsupported by Redshift:
 - EVERY
 - CONVERT
 - FORMAT
+
+LANGUAGE:
+Any natural-language text in your response (e.g., the "description") must be in the same language as the user's question. If the language cannot be determined, default to English. SQL remains SQL.
+
+REATTEMPT:
+It's possible that your query will fail due to a SQL error or return an empty result set.
+If this happens, you will be provided the failed query and the error message.
+Take this failed SQL code and error message into consideration when building your query so that the problem doesn't happen again.
 """.strip()
 
-    def adapt_datasource_to_table_context(
-        self, *, catalog: str | None = None, schema: str | None = None
-    ) -> dict[str, str]:
-        context = {}
-        if catalog:
-            context["Catalog"] = catalog
-        if schema:
-            context["Schema"] = schema
-        return context
+SYSTEM_PROMPT_POSTGRES = """
+Your job is to write a Postgres SQL query that analyzes one or more tables.
+The query will be executed against these tables, performing the necessary calculations and aggregations required to answer the user's business question.
+Carefully inspect the information and metadata provided to ensure your query will execute and return data.
+The result set should not only answer the question, but provide the necessary context so the user can fully understand how the data answers the question.
+For example, if the user asks, "Which State has the highest revenue?" Your query might return the top 10 states by revenue sorted in descending order since this would help the user understand how the state with the highest revenue compares to the other states.
+
+CONTEXT:
+You will be provided a data dictionary for the tables that identifies the data type and meaning of each column.
+You will also be provided a small sample of data from the table. This will help you understand the content of the columns as you build your query reducing the risk of errors.
+You will also be provided a list of frequently occurring values from VARCHAR / categorical columns. This will be helpful when adding WHERE clauses in your query.
+Based on this metadata, build your query so that it will run without error and return data.
+Your query should return not just the facts directly related to the question, but also return related information that could be part of the root cause or provide additional analytics value.
+Your query will be executed with Postgres SQL.
+
+RESPONSE:
+Your response shall be a single, executable Postgres SQL query that retrieves, analyzes, aggregates and returns the information required to answer the user's question.
+In addition, your response should return any relevant, supporting or contextual information to help the user better understand the results.
+Try to ensure that your query does not return an empty result set.
+Your code may not include any operations that could alter or corrupt the data.
+You may not use DELETE, UPDATE, TRUNCATE, DROP, DML Operations, ALTER TABLE or anything that could permanently alter the data.
+Your code should be robust against errors, with a high likelihood of successfully executing.
+The dataset may contain very large amounts of data. Your query result must not be excessively lengthy, therefore consider appropriate GROUP BY clauses and aggregations.
+The result of this query will be analyzed by humans and plotted in charts, so consider appropriate ways to organize and sort the data so that it is easy to interpret.
+Do not provide multiple queries that must be executed in different steps – the query must execute in a single step.
+Include comments to explain your code.
+Your response shall be formatted as JSON with the following fields:
+1) code: Postgres SQL code that will execute and return the data
+2) description: A brief description of how the code works, and how the results can be interpreted to answer the question.
+
+NECESSARY CONSIDERATIONS:
+Carefully consider the metadata and the sample data when constructing your query to avoid errors or an empty result.
+For example, seemingly numeric columns might contain non-numeric formatting such as $1,234.91 which could require special handling.
+This query will be executed using PostgreSQL.
+Use standard Postgres SQL syntax and functions.
+When performing date operations on a date column, consider using appropriate PostgreSQL date functions for error redundancy.
+The table name will be provided in fully quoted form, with catalog and schema (if present). No need to add quotes.
+
+LANGUAGE:
+Any natural-language text in your response (e.g., the "description") must be in the same language as the user's question. If the language cannot be determined, default to English. SQL remains SQL.
+
+REATTEMPT:
+It's possible that your query will fail due to a SQL error or return an empty result set.
+If this happens, you will be provided the failed query and the error message.
+Take this failed SQL code and error message into consideration when building your query so that the problem doesn't happen again.
+""".strip()


### PR DESCRIPTION
## 概要

upstream `datarobot-community/talk-to-my-data-agent` の `v0.3.20` タグ差分を `dev` に取り込むPRです。

## 取り込み内容

- `utils/analyst_db.py`: dataset metadata に original column types を保持する upstream 修正
- `utils/api.py`: remote/datasource preview response の扱いと database analysis prompt context の修正
- `utils/datarobot_dataset_handler.py`: dataset preview/type handling の upstream 修正
- `utils/prompts.py`: SQL prompt の展開・整理
- `CHANGELOG.md`: upstream `0.3.20` の記録を追加
- `customize_docs/upstream_sync_plan.md`: タグ単位の取り込み計画と判断ログを追加

## 競合対応

- `CHANGELOG.md` のみ競合しました。
- upstream の `0.3.20` 記述と、こちらの `0.3.19.1` カスタム履歴を両方残して解消しています。

## カスタム機能保護

- カスタムAPIルーターが FastAPI アプリに mount されていることを確認する characterization test を追加しました。
- このテスト追加時に、`Report` API が使う `python-docx` が `app_backend/pyproject.toml` に不足していることを検知したため追加しました。

## テスト

- `uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py`
  - 16 passed, 2 skipped
- `uv run ruff check app_backend/tests/test_main.py`
  - passed

## 次の同期候補

次PRは `v0.3.21` を予定しています。読み取り専用マージでは `CHANGELOG.md` のみ競合見込みですが、README/env/API差分を確認してから進めます。
