### PR TITLE
Sync upstream v0.3.21

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,11 +1,11 @@
 # Refer to https://docs.datarobot.com/en/docs/api/api-quickstart/index.html#create-a-datarobot-api-key
 # and https://docs.datarobot.com/en/docs/api/api-quickstart/index.html#retrieve-the-api-endpoint
 # Can be deleted on a DataRobot codespace
-DATAROBOT_API_TOKEN=
-DATAROBOT_ENDPOINT=
+# DATAROBOT_API_TOKEN=
+# DATAROBOT_ENDPOINT=
 
 # Required, unless logged in to pulumi cloud. Choose your own alphanumeric passphrase to be used for encrypting pulumi config
-PULUMI_CONFIG_PASSPHRASE=123
+PULUMI_CONFIG_PASSPHRASE=1234abc
 
 # Optional: Choose which frontend implementation to use (streamlit or react)
 # FRONTEND_TYPE=react

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## [0.3.21] - 2025-11-24
+
+### Improvements
+
+- Improve scalability of DataWrangling usage.
+- Tweaked Redshift prompt to better handle epoch timestamps.
+
+### Fixes
+
+- Root cause messages not propagated for some query failures through DataRobot DataWrangling.
+
 ## [0.3.20] - 2025-11-20
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.20] - 2025-11-20
+
+### Improvements
+
+- Improved data type handling for DataRobot connections.
+- Unrolled templated prompts for ease of editing.
+
 ## [0.3.19] - 2025-11-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This intuitive experience is designed for **scalability and flexibility**, ensur
 
 ## Table of contents
 
-1. [Quick Start](#quick-start)
+1. [Quick Start](#-quick-start)
 2. [User's Guide](#users-guide)
 3. [Setup](#setup)
 4. [Architecture overview](#architecture-overview)
@@ -29,9 +29,120 @@ This intuitive experience is designed for **scalability and flexibility**, ensur
 10. [Delete all provisioned resources](#delete-all-provisioned-resources)
 11. [Setup for advanced users](#setup-for-advanced-users)
 
-## Quick Start
+## 🚀 Quick Start
 
-Please check out this [Talk To My Data walkthrough](https://docs.datarobot.com/en/docs/get-started/gs-dr5/talk-data-walk.html).
+### Build in Codespace
+
+If you're using **DataRobot Codespace**, everything you need is already installed.
+Follow the steps below to launch the entire application in just a few minutes.
+
+#### 1. Set Up Your Environment File
+
+1.  Rename `.env.template` → `.env`
+2.  Open the new `.env` file and fill in the required values.\
+    For local use, these can be simple placeholder strings:
+
+- `PULUMI_CONFIG_PASSPHRASE=1234abc` — A passphrase for Pulumi (any string works locally)
+- `USE_DATAROBOT_LLM_GATEWAY=true` to use DataRobot LLM Gateway
+
+#### 2. Install & Deploy
+
+Use the built-in terminal on the left sidebar of the Codespace.
+
+From the project root:
+
+```sh
+python quickstart.py YOUR_PROJECT_NAME
+```
+
+Replace `YOUR_PROJECT_NAME` with any name you prefer, then press **Enter**.
+
+When deployment completes, the terminal will display a link to your running application.\
+👉 **Click the link to open and start using your app!**
+
+Additionally, please find a guided Talk To My Data walkthrough [here](https://docs.datarobot.com/en/docs/get-started/gs-dr5/talk-data-walk.html).
+
+### Build Locally
+
+For local development, follow all of the steps below.
+
+#### 1. Install Pulumi (if you don’t have it yet)
+
+If Pulumi is not already installed, follow the installation instructions in the Pulumi [documentation](https://www.pulumi.com/docs/iac/download-install/).
+After installing for the first time, **restart your terminal** and run:
+
+```sh
+pulumi login --local      # omit --local to use Pulumi Cloud (requires an account)
+```
+
+#### 2. Clone the Template Repository
+
+```sh
+git clone https://github.com/datarobot-community/talk-to-my-data-agent.git
+cd talk-to-my-data-agent
+```
+
+#### 3. Create and Populate Your `.env` File
+
+Rename `.env.template` → `.env`, then fill in the required credentials:
+
+```sh
+DATAROBOT_API_TOKEN=...             # Required.
+DATAROBOT_ENDPOINT=...              # Required. e.g. https://app.datarobot.com/api/v2
+
+OPENAI_API_KEY=...
+OPENAI_API_VERSION=...              # e.g. 2024-02-01
+OPENAI_API_BASE=...                 # e.g. https://your_org.openai.azure.com/
+OPENAI_API_DEPLOYMENT_ID=...        # e.g. gpt-4o
+
+PULUMI_CONFIG_PASSPHRASE=...        # Required. Choose any alphanumeric passphrase used to encrypt Pulumi config.
+
+FRONTEND_TYPE=...                   # Optional: "react" (default) or "streamlit"
+USE_DATAROBOT_LLM_GATEWAY=...       # Optional: "true" to use DataRobot LLM Gateway
+```
+
+**Where to Find Your Credentials**
+
+- **DataRobot API Token:**
+  See Create a DataRobot API Key in the [DataRobot API Quickstart docs](https://docs.datarobot.com/en/docs/api/api-quickstart/index.html#create-a-datarobot-api-key).
+
+- **DataRobot Endpoint:**
+  See Retrieve the API Endpoint in the same [Quickstart docs](https://docs.datarobot.com/en/docs/api/api-quickstart/index.html#retrieve-the-api-endpoint).
+
+- **LLM Endpoint & API Key (Azure OpenAI):**
+  Refer to the [Azure OpenAI documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart?tabs=command-line%2Cjavascript-keyless%2Ctypescript-keyless%2Cpython-new&pivots=programming-language-python#retrieve-key-and-endpoint) for your resource and deployment values.
+
+#### 4. Deploy the Project
+
+From the project root:
+
+```sh
+python quickstart.py YOUR_PROJECT_NAME
+# Windows users may need:  py quickstart.py YOUR_PROJECT_NAME
+```
+
+Replace `YOUR_PROJECT_NAME` with any name you prefer, then press **Enter**.
+
+When deployment completes, the terminal will display a link to your running application.\
+👉 **Click the link to open and start using your app!**
+
+**What does `quickstart.py` do?**
+
+The quickstart script automates the entire setup process for you:
+
+- Creates and activates a Python virtual environment
+- Installs all required dependencies (using `uv` for faster installation, falling back to `pip`)
+- Loads your `.env` configuration
+- Sets up the Pulumi stack with your project name
+- Runs `pulumi up` to deploy your application
+- Displays your application URL when complete
+
+This single command replaces all the manual steps described in the [advanced setup section](#setup-for-advanced-users).
+
+Python 3.10 - 3.12 are supported
+
+Advanced users desiring control over virtual environment creation, dependency installation, environment variable setup
+and `pulumi` invocation see [here](#setup-for-advanced-users).
 
 ## User's Guide
 
@@ -46,7 +157,7 @@ Large datasets can be uploaded to the DataRobot platform (see [this documentatio
 Items from the user's data registry can be connected to the application (see screenshot below). These items are not downloaded into the application, but instead
 analysis is performed through DataRobot's data wrangling platform. This performs efficient queries that can support larger datasets (we have validated at least 5GB).
 Note there is a several minute cold start with the platform as it creates the analysis environment and loads data. These datasets can also be added locally,
-which will avoid this cold start, and is suitable for smaller files. 
+which will avoid this cold start, and is suitable for smaller files.
 
 ![Remote Data Registry screenshot.](_docs/images/screenshot-remote-data-registry.png)
 
@@ -62,7 +173,6 @@ the data store and its default credentials in the DataRobot platform.
 
 ![Add Remote Data Connection](_docs/images/screenshot-remote-data-connections.png)
 
-
 ## Setup
 
 Before proceeding, ensure you have access to the required credentials and services. This template is pre-configured to use an Azure OpenAI endpoint and Snowflake Database credentials. To run the template as-is, you will need access to Azure OpenAI (leverages `gpt-4o` by default).
@@ -74,68 +184,6 @@ Before proceeding, ensure you have access to the required credentials and servic
 - [Taskfile.dev](https://taskfile.dev/#/installation) (task runner)
 - [Node.js](https://nodejs.org/en/download/) 18+ (for React frontend)
 - [Pulumi](https://www.pulumi.com/docs/iac/download-install/) (infrastructure as code)
-
-**DataRobot Codespaces users:** If you opened this template from the [Application Templates gallery](https://docs.datarobot.com/en/docs/workbench/wb-apps/app-templates/index.html#application-templates), you can **skip steps 1 and 2**. If you created a fresh codespace, you can **skip step 1** but still need to **clone the repository (step 2)**.
-
-**For local development,** follow all of the following steps:
-
-1. If `pulumi` is not already installed, install the CLI following instructions [here](https://www.pulumi.com/docs/iac/download-install/).
-   After installing for the first time, restart your terminal and run:
-
-   ```bash
-   pulumi login --local  # omit --local to use Pulumi Cloud (requires separate account)
-   ```
-
-2. Clone the template repository
-
-   ```bash
-   git clone https://github.com/datarobot-community/talk-to-my-data-agent.git
-   cd talk-to-my-data-agent
-   ```
-
-3. Rename the file `.env.template` to `.env` in the root directory of the repo and populate your credentials.
-
-   ```bash
-   DATAROBOT_API_TOKEN=...
-   DATAROBOT_ENDPOINT=...  # e.g. https://app.datarobot.com/api/v2
-   OPENAI_API_KEY=...
-   OPENAI_API_VERSION=...  # e.g. 2024-02-01
-   OPENAI_API_BASE=...  # e.g. https://your_org.openai.azure.com/
-   OPENAI_API_DEPLOYMENT_ID=...  # e.g. gpt-4o
-   PULUMI_CONFIG_PASSPHRASE=...  # Required. Choose your own alphanumeric passphrase to be used for encrypting pulumi config
-   FRONTEND_TYPE=...  # Optional. Default is "react", set to "streamlit" to use Streamlit frontend
-   USE_DATAROBOT_LLM_GATEWAY=...  # Optional. Set to "true" to use DataRobot LLM Gateway with consumption based pricing instead of using your own LLM credentials
-   ```
-
-   Use the following resources to locate the required credentials:
-
-   - **DataRobot API Token**: Refer to the _Create a DataRobot API Key_ section of the [DataRobot API Quickstart docs](https://docs.datarobot.com/en/docs/api/api-quickstart/index.html#create-a-datarobot-api-key).
-   - **DataRobot Endpoint**: Refer to the _Retrieve the API Endpoint_ section of the same [DataRobot API Quickstart docs](https://docs.datarobot.com/en/docs/api/api-quickstart/index.html#retrieve-the-api-endpoint).
-   - **LLM Endpoint and API Key**: Refer to the [Azure OpenAI documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart?tabs=command-line%2Cjavascript-keyless%2Ctypescript-keyless%2Cpython-new&pivots=programming-language-python#retrieve-key-and-endpoint).
-
-4. In a terminal, run:
-
-   ```bash
-   python quickstart.py YOUR_PROJECT_NAME  # Windows users may have to use `py` instead of `python`
-   ```
-
-   **What does `quickstart.py` do?**
-
-   The quickstart script automates the entire setup process for you:
-
-   - Creates and activates a Python virtual environment
-   - Installs all required dependencies (using `uv` for faster installation, falling back to `pip`)
-   - Loads your `.env` configuration
-   - Sets up the Pulumi stack with your project name
-   - Runs `pulumi up` to deploy your application
-   - Displays your application URL when complete
-
-   This single command replaces all the manual steps described in the [advanced setup section](#setup-for-advanced-users).
-
-   Python 3.10 - 3.12 are supported
-
-Advanced users desiring control over virtual environment creation, dependency installation, environment variable setup
-and `pulumi` invocation see [here](#setup-for-advanced-users).
 
 ## Template development
 

--- a/app_backend/pyproject.toml
+++ b/app_backend/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "pydantic==2.7.4,<3.0",
     "pydantic-settings==2.4.0,<3.0",
     "python-dotenv>=1.0.1",
+    "python-docx>=1.1.0,<2.0",
     "python-multipart>=0.0.20,<1.0",
     "scikit-learn>=1.6.1,<2.0",
     "scipy>=1.15.1,<2.0",

--- a/app_backend/tests/test_main.py
+++ b/app_backend/tests/test_main.py
@@ -38,6 +38,18 @@ def test_reports_spa_routes() -> None:
         assert response.headers["content-type"] == "text/html; charset=utf-8"
 
 
+def test_customize_api_routes_are_mounted() -> None:
+    paths = {
+        getattr(route, "path", "")
+        for route in app.routes
+        if getattr(route, "path", "").startswith("/api/v1")
+    }
+
+    assert "/api/v1/config/feature-flags" in paths
+    assert "/api/v1/refiner" in paths
+    assert "/api/v1/reports" in paths
+
+
 def test_favicon_file() -> None:
     response = client.get("/datarobot_favicon.png")
     assert response.status_code == 200

--- a/app_frontend/src/components/chat/ErrorPanel.tsx
+++ b/app_frontend/src/components/chat/ErrorPanel.tsx
@@ -26,7 +26,7 @@ export const ErrorPanel: React.FC<ErrorPanelProps> = ({
     <>
       {attempts && (
         <h2 className="mb-2">
-          {t('Failed to generate valid code after {attempts} attempts', { attempts })}
+          {t('Failed to generate valid code after {{attempts}} attempts', { attempts })}
         </h2>
       )}
       {errors.map(e => {

--- a/app_frontend/src/i18n/locales/es_419.json
+++ b/app_frontend/src/i18n/locales/es_419.json
@@ -20,7 +20,7 @@
   "Dataset": "Conjunto de datos",
   "Code": "Código",
   "Toggle panel": "Alternar panel",
-  "Failed to generate valid code after {attempts} attempts": "No se pudo generar código válido después de {attempts} intentos",
+  "Failed to generate valid code after {{attempts}} attempts": "No se pudo generar código válido después de {{attempts}} intentos",
   "An error occurred during execution": "Ocurrió un error durante la ejecución",
   "Code that caused the error:": "Código que causó el error:",
   "Traceback:": "Rastreo:",

--- a/app_frontend/src/i18n/locales/fr.json
+++ b/app_frontend/src/i18n/locales/fr.json
@@ -20,7 +20,7 @@
   "Dataset": "Jeu de données",
   "Code": "Code",
   "Toggle panel": "Basculer le panneau",
-  "Failed to generate valid code after {attempts} attempts": "Échec de la génération d'un code valide après {attempts} tentatives",
+  "Failed to generate valid code after {{attempts}} attempts": "Échec de la génération d'un code valide après {{attempts}} tentatives",
   "An error occurred during execution": "Une erreur s'est produite pendant l'exécution",
   "Code that caused the error:": "Code qui a causé l'erreur:",
   "Traceback:": "Traceback:",

--- a/app_frontend/src/i18n/locales/ja.json
+++ b/app_frontend/src/i18n/locales/ja.json
@@ -20,7 +20,7 @@
   "Dataset": "データセット",
   "Code": "コード",
   "Toggle panel": "パネルを表示/非表示",
-  "Failed to generate valid code after {attempts} attempts": "{attempts}回試しても有効なコードを生成できませんでした",
+  "Failed to generate valid code after {{attempts}} attempts": "{attempts}回試しても有効なコードを生成できませんでした",
   "An error occurred during execution": "実行中にエラーが発生しました",
   "Code that caused the error:": "エラーの原因となったコード：",
   "Traceback:": "トレースバック：",

--- a/app_frontend/src/i18n/locales/ko.json
+++ b/app_frontend/src/i18n/locales/ko.json
@@ -20,7 +20,7 @@
   "Dataset": "데이터셋",
   "Code": "코드",
   "Toggle panel": "패널 토글",
-  "Failed to generate valid code after {attempts} attempts": "{attempts}번 시도 후 유효한 코드 생성에 실패했습니다",
+  "Failed to generate valid code after {{attempts}} attempts": "{{attempts}}번 시도 후 유효한 코드 생성에 실패했습니다",
   "An error occurred during execution": "실행 중 오류가 발생했습니다",
   "Code that caused the error:": "오류를 발생시킨 코드:",
   "Traceback:": "오류 추적:",

--- a/app_frontend/src/i18n/locales/pt_BR.json
+++ b/app_frontend/src/i18n/locales/pt_BR.json
@@ -21,7 +21,7 @@
   "Dataset": "Conjunto de Dados",
   "Code": "Código",
   "Toggle panel": "Alternar painel",
-  "Failed to generate valid code after {attempts} attempts": "Falha ao gerar código válido após {attempts} tentativas",
+  "Failed to generate valid code after {{attempts}} attempts": "Falha ao gerar código válido após {{attempts}} tentativas",
   "An error occurred during execution": "Ocorreu um erro durante a execução",
   "Code that caused the error:": "Código que causou o erro:",
   "Traceback:": "Rastreamento (traceback):",

--- a/customize_docs/upstream_sync_plan.md
+++ b/customize_docs/upstream_sync_plan.md
@@ -36,9 +36,8 @@
 
 | タグ | ブランチ | 判断 | 主な差分 | 競合/注意点 | テスト |
 | --- | --- | --- | --- | --- | --- |
-| `v0.3.20` | `codex/upstream-sync-v0.3.20` | 取り込む | `utils/analyst_db.py`, `utils/api.py`, `utils/datarobot_dataset_handler.py`, `utils/prompts.py` | `CHANGELOG.md` のみ競合。内容を両方残す方針で解消する。 | 実行予定 |
+| `v0.3.20` | `codex/upstream-sync-v0.3.20` | 取り込む | `utils/analyst_db.py`, `utils/api.py`, `utils/datarobot_dataset_handler.py`, `utils/prompts.py` | `CHANGELOG.md` のみ競合。内容を両方残して解消済み。カスタムAPIのcharacterization test追加時に `python-docx` が `app_backend/pyproject.toml` に不足していることを検知し、依存関係を追加。 | `uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py`: 16 passed, 2 skipped |
 | `v0.3.21` | 未作成 | 取り込む候補 | `.env.template`, `README.md`, i18n, `utils/api.py`, `utils/rest_api.py`, dataset handling | 読み取り専用マージでは `CHANGELOG.md` のみ競合。README/env/API差分は確認してからPR化する。 | 未実行 |
 | `v0.3.22` | 未作成 | 取り込む候補 | frontend select UI, `utils/base_telemetry.py` | 読み取り専用マージでは `CHANGELOG.md` のみ競合。UI差分のためfrontend検証を追加する。 | 未実行 |
 | `v0.3.23` | 未作成 | 取り込む候補 | `infra/__main__.py`, `requirements.txt`, dataset handling | 読み取り専用マージでは `CHANGELOG.md` のみ競合。infra差分はPulumi設定への影響を確認する。 | 未実行 |
 | `v0.4.24` 以降 | 未作成 | 別判断 | 大きな構成変更を含む可能性 | `utils -> core/src/core` の移植判断が必要。専用PRで扱う。 | 未実行 |
-

--- a/customize_docs/upstream_sync_plan.md
+++ b/customize_docs/upstream_sync_plan.md
@@ -37,7 +37,7 @@
 | タグ | ブランチ | 判断 | 主な差分 | 競合/注意点 | テスト |
 | --- | --- | --- | --- | --- | --- |
 | `v0.3.20` | `codex/upstream-sync-v0.3.20` | 取り込む | `utils/analyst_db.py`, `utils/api.py`, `utils/datarobot_dataset_handler.py`, `utils/prompts.py` | `CHANGELOG.md` のみ競合。内容を両方残して解消済み。カスタムAPIのcharacterization test追加時に `python-docx` が `app_backend/pyproject.toml` に不足していることを検知し、依存関係を追加。 | `uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py`: 16 passed, 2 skipped |
-| `v0.3.21` | 未作成 | 取り込む候補 | `.env.template`, `README.md`, i18n, `utils/api.py`, `utils/rest_api.py`, dataset handling | 読み取り専用マージでは `CHANGELOG.md` のみ競合。README/env/API差分は確認してからPR化する。 | 未実行 |
+| `v0.3.21` | `codex/upstream-sync-v0.3.21` | 取り込む | `.env.template`, `README.md`, i18n, `utils/api.py`, `utils/rest_api.py`, dataset handling | 実マージでは競合なし。upstream追加の `pytest.ini` が既存 `pyproject.toml` の pytest 設定を上書きし `app` import を壊したため、既存設定を `pytest.ini` に統合。 | `uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py`: 16 passed, 2 skipped; `npm --prefix app_frontend test`: 103 passed; `npm --prefix app_frontend run lint`: passed |
 | `v0.3.22` | 未作成 | 取り込む候補 | frontend select UI, `utils/base_telemetry.py` | 読み取り専用マージでは `CHANGELOG.md` のみ競合。UI差分のためfrontend検証を追加する。 | 未実行 |
 | `v0.3.23` | 未作成 | 取り込む候補 | `infra/__main__.py`, `requirements.txt`, dataset handling | 読み取り専用マージでは `CHANGELOG.md` のみ競合。infra差分はPulumi設定への影響を確認する。 | 未実行 |
 | `v0.4.24` 以降 | 未作成 | 別判断 | 大きな構成変更を含む可能性 | `utils -> core/src/core` の移植判断が必要。専用PRで扱う。 | 未実行 |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    remote_datasource_concurrency: Integration / concurrency test
+addopts = -m "not remote_datasource_concurrency"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,11 @@
 [pytest]
+pythonpath =
+    app_backend
+    .
+norecursedirs = tests/e2e
+asyncio_default_fixture_loop_scope = module
+filterwarnings =
+    ignore::DeprecationWarning::
 markers =
     remote_datasource_concurrency: Integration / concurrency test
 addopts = -m "not remote_datasource_concurrency"

--- a/utils/api.py
+++ b/utils/api.py
@@ -1761,7 +1761,7 @@ async def run_complete_analysis(
             )
         elif isinstance(data_source, ExternalDataStoreNameDataSourceType):
             logger.info("Running DataStore DataWrangling analysis")
-            data_store_id = DataSourceRecipe.get_id_for_data_store_canonical_name(
+            data_store_id = await DataSourceRecipe.get_id_for_data_store_canonical_name(
                 data_source.friendly_name
             )
             if not data_store_id:

--- a/utils/prompts.py
+++ b/utils/prompts.py
@@ -643,6 +643,12 @@ Use standard Redshift SQL syntax and functions.
 When performing date operations on a date column, consider using appropriate Redshift date functions for error redundancy.
 The table name will be provided in fully quoted form, with catalog and schema (if present). No need to add quotes.
 
+To display an integer timestamp column (epoch seconds, milliseconds or nanoseconds), the following expression will convert from integer timestamp to a friendly timestamp.
+
+    TIMESTAMP 'epoch' + ({column_name} / CONVERSION_FACTOR) * INTERVAL '1 second' AS {column_name}_value
+
+Where `{column_name}` is the name of the column and `CONVERSION_FACTOR` is the number of nanoseconds in the given time unit (e.g. for nanoseconds this is 1000000000).
+
 Redshift's query language is mostly equal to PostgreSQL, but it does not support all PostgreSQL functions. 
 Do NOT attempt to use any of the following functions unsupported by Redshift:
 - STRING_AGG

--- a/utils/prompts.py
+++ b/utils/prompts.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import abc
 
-from jinja2 import Environment
 
 SYSTEM_PROMPT_GET_DICTIONARY = """
 YOUR ROLE:
@@ -559,26 +557,9 @@ If this happens, you will be provided the failed query and the error message.
 Take this failed SQL code and error message into consideration when building your query so that the problem doesn't happen again.
 """
 
-
-def sql_prompt_template(
-    *,
-    language_variant: str,
-    base_language: str,
-    execution_environment: str,
-    table_context: dict[str, str],
-    extra_necessary_considerations: str,
-    prohibited_commands_example: str,
-    varchar_categorical: str,
-    where: str,
-    group_by: str,
-) -> str:
-    sql_variant = f"{language_variant} {base_language}"
-    return (
-        Environment()
-        .from_string(
-            """
+SYSTEM_PROMPT_SPARK_SQL = """
 ROLE:
-Your job is to write a {{sql_variant}} query that analyzes one or more tables.
+Your job is to write a Spark SQL query that analyzes one or more tables.
 The query will be executed against these tables, performing the necessary calculations and aggregations required to answer the user's business question.
 Carefully inspect the information and metadata provided to ensure your query will execute and return data.
 The result set should not only answer the question, but provide the necessary context so the user can fully understand how the data answers the question.
@@ -587,191 +568,78 @@ For example, if the user asks, "Which State has the highest revenue?" Your query
 CONTEXT:
 You will be provided a data dictionary for the tables that identifies the data type and meaning of each column.
 You will also be provided a small sample of data from the table. This will help you understand the content of the columns as you build your query reducing the risk of errors.
-You will also be provided a list of frequently occurring values from {{varchar_categorical}} columns. This will be helpful when adding {{where}} clauses in your query.
+You will also be provided a list of frequently occurring values from VARCHAR / categorical columns. This will be helpful when adding WHERE clauses in your query.
 Based on this metadata, build your query so that it will run without error and return data.
 Your query should return not just the facts directly related to the question, but also return related information that could be part of the root cause or provide additional analytics value.
-Your query will be executed with {{sql_variant}}.
+Your query will be executed with Spark SQL.
 
 RESPONSE:
-Your response shall be a single, executable {{sql_variant}} query that retrieves, analyzes, aggregates and returns the information required to answer the user's question.
+Your response shall be a single, executable Spark SQL query that retrieves, analyzes, aggregates and returns the information required to answer the user's question.
 In addition, your response should return any relevant, supporting or contextual information to help the user better understand the results.
 Try to ensure that your query does not return an empty result set.
 Your code may not include any operations that could alter or corrupt the data.
-You may not use {{prohibited_commands_example}} or anything that could permanently alter the data.
+You may not use DELETE, UPDATE, TRUNCATE, DROP, DML Operations, ALTER TABLE or anything that could permanently alter the data.
 Your code should be robust against errors, with a high likelihood of successfully executing.
-The dataset may contain very large amounts of data. Your query result must not be excessively lengthy, therefore consider appropriate {{group_by}} clauses and aggregations.
+The dataset may contain very large amounts of data. Your query result must not be excessively lengthy, therefore consider appropriate GROUP BY clauses and aggregations.
 The result of this query will be analyzed by humans and plotted in charts, so consider appropriate ways to organize and sort the data so that it is easy to interpret.
 Do not provide multiple queries that must be executed in different steps – the query must execute in a single step.
 Include comments to explain your code.
 Your response shall be formatted as JSON with the following fields:
-1) code: {{sql_variant}} code that will execute and return the data
+1) code: Spark SQL code that will execute and return the data
 2) description: A brief description of how the code works, and how the results can be interpreted to answer the question.
-{% if table_context %}
-{{execution_environment.upper()}} ENVIRONMENT:
-{% for k, v in table_context.items() %}
-{{k}}: {{v}}
-{% endfor %}
-{% endif %}
+
 NECESSARY CONSIDERATIONS:
 Carefully consider the metadata and the sample data when constructing your query to avoid errors or an empty result.
 For example, seemingly numeric columns might contain non-numeric formatting such as $1,234.91 which could require special handling.
-This query will be executed using {{execution_environment}}.
-Use standard {{sql_variant}} syntax and functions.
-{{extra_necessary_considerations}}
-
-LANGUAGE:
-Any natural-language text in your response (e.g., the "description") must be in the same language as the user's question. If the language cannot be determined, default to English. {{base_language}} remains {{base_language}}.
-
-REATTEMPT:
-It's possible that your query will fail due to a {{base_language}} error or return an empty result set.
-If this happens, you will be provided the failed query and the error message.
-Take this failed {{base_language}} code and error message into consideration when building your query so that the problem doesn't happen again.
-"""
-        )
-        .render(locals())
-        .strip()
-    )
-
-
-class QueryPromptFactory(abc.ABC):
-    @property
-    @abc.abstractmethod
-    def language_variant(self) -> str:
-        pass
-
-    @property
-    def base_language(self) -> str:
-        return "SQL"
-
-    @property
-    @abc.abstractmethod
-    def execution_environment(self) -> str:
-        pass
-
-    @property
-    def extra_necessary_considerations(self) -> str:
-        return ""
-
-    @property
-    def prohibited_commands_example(self) -> str:
-        return "DELETE, UPDATE, TRUNCATE, DROP, DML Operations, ALTER TABLE"
-
-    @property
-    def varchar_categorical(self) -> str:
-        return "VARCHAR / categorical"
-
-    @property
-    def where(self) -> str:
-        return "WHERE"
-
-    @property
-    def group_by(self) -> str:
-        return "GROUP BY"
-
-    @abc.abstractmethod
-    def adapt_datasource_to_table_context(
-        self,
-        *,
-        catalog: str | None = None,
-        schema: str | None = None,
-    ) -> dict[str, str]:
-        pass
-
-    def prompt_for_datasource(
-        self,
-        *,
-        catalog: str | None = None,
-        schema: str | None = None,
-    ) -> str:
-        return sql_prompt_template(
-            language_variant=self.language_variant,
-            base_language=self.base_language,
-            execution_environment=self.execution_environment,
-            table_context=self.adapt_datasource_to_table_context(
-                catalog=catalog, schema=schema
-            ),
-            extra_necessary_considerations=self.extra_necessary_considerations,
-            prohibited_commands_example=self.prohibited_commands_example,
-            where=self.where,
-            varchar_categorical=self.varchar_categorical,
-            group_by=self.group_by,
-        )
-
-    def adapt_table_path(self, path: str) -> str:
-        return path
-
-
-class SparkPromptFactory(QueryPromptFactory):
-    @property
-    def language_variant(self) -> str:
-        return "Spark"
-
-    @property
-    def execution_environment(self) -> str:
-        return "Spark SQL"
-
-    @property
-    def extra_necessary_considerations(self) -> str:
-        return """
+This query will be executed using Spark SQL.
+Use standard Spark SQL syntax and functions.
 When performing date operations on a date column, consider using appropriate Spark SQL date functions for error redundancy.
 Table references will be provided already properly quoted in backticks.
+
+LANGUAGE:
+Any natural-language text in your response (e.g., the "description") must be in the same language as the user's question. If the language cannot be determined, default to English. SQL remains SQL.
+
+REATTEMPT:
+It's possible that your query will fail due to a SQL error or return an empty result set.
+If this happens, you will be provided the failed query and the error message.
+Take this failed SQL code and error message into consideration when building your query so that the problem doesn't happen again.
 """.strip()
 
-    def adapt_table_path(self, path: str) -> str:
-        return f"`{path}`"
+SYSTEM_PROMPT_REDSHIFT = """
+Your job is to write a Redshift SQL query that analyzes one or more tables.
+The query will be executed against these tables, performing the necessary calculations and aggregations required to answer the user's business question.
+Carefully inspect the information and metadata provided to ensure your query will execute and return data.
+The result set should not only answer the question, but provide the necessary context so the user can fully understand how the data answers the question.
+For example, if the user asks, "Which State has the highest revenue?" Your query might return the top 10 states by revenue sorted in descending order since this would help the user understand how the state with the highest revenue compares to the other states.
 
-    def adapt_datasource_to_table_context(
-        self, *, catalog: str | None = None, schema: str | None = None
-    ) -> dict[str, str]:
-        if catalog or schema:
-            raise ValueError("Catalog/Schema not supported for Spark.")
-        return {}
+CONTEXT:
+You will be provided a data dictionary for the tables that identifies the data type and meaning of each column.
+You will also be provided a small sample of data from the table. This will help you understand the content of the columns as you build your query reducing the risk of errors.
+You will also be provided a list of frequently occurring values from VARCHAR / categorical columns. This will be helpful when adding WHERE clauses in your query.
+Based on this metadata, build your query so that it will run without error and return data.
+Your query should return not just the facts directly related to the question, but also return related information that could be part of the root cause or provide additional analytics value.
+Your query will be executed with Redshift SQL.
 
+RESPONSE:
+Your response shall be a single, executable Redshift SQL query that retrieves, analyzes, aggregates and returns the information required to answer the user's question.
+In addition, your response should return any relevant, supporting or contextual information to help the user better understand the results.
+Try to ensure that your query does not return an empty result set.
+Your code may not include any operations that could alter or corrupt the data.
+You may not use DELETE, UPDATE, TRUNCATE, DROP, DML Operations, ALTER TABLE or anything that could permanently alter the data.
+Your code should be robust against errors, with a high likelihood of successfully executing.
+The dataset may contain very large amounts of data. Your query result must not be excessively lengthy, therefore consider appropriate GROUP BY clauses and aggregations.
+The result of this query will be analyzed by humans and plotted in charts, so consider appropriate ways to organize and sort the data so that it is easy to interpret.
+Do not provide multiple queries that must be executed in different steps – the query must execute in a single step.
+Include comments to explain your code.
+Your response shall be formatted as JSON with the following fields:
+1) code: Redshift SQL code that will execute and return the data
+2) description: A brief description of how the code works, and how the results can be interpreted to answer the question.
 
-class PostgresPromptFactory(QueryPromptFactory):
-    @property
-    def language_variant(self) -> str:
-        return "Postgres"
-
-    @property
-    def execution_environment(self) -> str:
-        return "PostgreSQL"
-
-    @property
-    def extra_necessary_considerations(self) -> str:
-        return """
-When performing date operations on a date column, consider using appropriate PostgreSQL date functions for error redundancy.
-The table name will be provided in fully quoted form, with catalog and schema (if present). No need to add quotes.
-""".strip()
-
-    def adapt_datasource_to_table_context(
-        self, *, catalog: str | None = None, schema: str | None = None
-    ) -> dict[str, str]:
-        context = {}
-        if catalog:
-            context["Catalog"] = catalog
-        if schema:
-            context["Schema"] = schema
-        return context
-
-    def adapt_table_path(self, path: str) -> str:
-        return ".".join(f'"{part}"' for part in path.split("."))
-
-
-class RedshiftPromptFactory(PostgresPromptFactory):
-    @property
-    def language_variant(self) -> str:
-        return "Redshift (PostgreSQL)"
-
-    @property
-    def execution_environment(self) -> str:
-        return "Redshift"
-
-    @property
-    def extra_necessary_considerations(self) -> str:
-        # See https://docs.aws.amazon.com/redshift/latest/dg/c_redshift-and-postgres-sql.html
-        # In order to not bloat the prompt, I'm not listing every difference below, just some  key ones.
-        return """
+NECESSARY CONSIDERATIONS:
+Carefully consider the metadata and the sample data when constructing your query to avoid errors or an empty result.
+For example, seemingly numeric columns might contain non-numeric formatting such as $1,234.91 which could require special handling.
+This query will be executed using Redshift.
+Use standard Redshift SQL syntax and functions.
 When performing date operations on a date column, consider using appropriate Redshift date functions for error redundancy.
 The table name will be provided in fully quoted form, with catalog and schema (if present). No need to add quotes.
 
@@ -782,14 +650,59 @@ Do NOT attempt to use any of the following functions unsupported by Redshift:
 - EVERY
 - CONVERT
 - FORMAT
+
+LANGUAGE:
+Any natural-language text in your response (e.g., the "description") must be in the same language as the user's question. If the language cannot be determined, default to English. SQL remains SQL.
+
+REATTEMPT:
+It's possible that your query will fail due to a SQL error or return an empty result set.
+If this happens, you will be provided the failed query and the error message.
+Take this failed SQL code and error message into consideration when building your query so that the problem doesn't happen again.
 """.strip()
 
-    def adapt_datasource_to_table_context(
-        self, *, catalog: str | None = None, schema: str | None = None
-    ) -> dict[str, str]:
-        context = {}
-        if catalog:
-            context["Catalog"] = catalog
-        if schema:
-            context["Schema"] = schema
-        return context
+SYSTEM_PROMPT_POSTGRES = """
+Your job is to write a Postgres SQL query that analyzes one or more tables.
+The query will be executed against these tables, performing the necessary calculations and aggregations required to answer the user's business question.
+Carefully inspect the information and metadata provided to ensure your query will execute and return data.
+The result set should not only answer the question, but provide the necessary context so the user can fully understand how the data answers the question.
+For example, if the user asks, "Which State has the highest revenue?" Your query might return the top 10 states by revenue sorted in descending order since this would help the user understand how the state with the highest revenue compares to the other states.
+
+CONTEXT:
+You will be provided a data dictionary for the tables that identifies the data type and meaning of each column.
+You will also be provided a small sample of data from the table. This will help you understand the content of the columns as you build your query reducing the risk of errors.
+You will also be provided a list of frequently occurring values from VARCHAR / categorical columns. This will be helpful when adding WHERE clauses in your query.
+Based on this metadata, build your query so that it will run without error and return data.
+Your query should return not just the facts directly related to the question, but also return related information that could be part of the root cause or provide additional analytics value.
+Your query will be executed with Postgres SQL.
+
+RESPONSE:
+Your response shall be a single, executable Postgres SQL query that retrieves, analyzes, aggregates and returns the information required to answer the user's question.
+In addition, your response should return any relevant, supporting or contextual information to help the user better understand the results.
+Try to ensure that your query does not return an empty result set.
+Your code may not include any operations that could alter or corrupt the data.
+You may not use DELETE, UPDATE, TRUNCATE, DROP, DML Operations, ALTER TABLE or anything that could permanently alter the data.
+Your code should be robust against errors, with a high likelihood of successfully executing.
+The dataset may contain very large amounts of data. Your query result must not be excessively lengthy, therefore consider appropriate GROUP BY clauses and aggregations.
+The result of this query will be analyzed by humans and plotted in charts, so consider appropriate ways to organize and sort the data so that it is easy to interpret.
+Do not provide multiple queries that must be executed in different steps – the query must execute in a single step.
+Include comments to explain your code.
+Your response shall be formatted as JSON with the following fields:
+1) code: Postgres SQL code that will execute and return the data
+2) description: A brief description of how the code works, and how the results can be interpreted to answer the question.
+
+NECESSARY CONSIDERATIONS:
+Carefully consider the metadata and the sample data when constructing your query to avoid errors or an empty result.
+For example, seemingly numeric columns might contain non-numeric formatting such as $1,234.91 which could require special handling.
+This query will be executed using PostgreSQL.
+Use standard Postgres SQL syntax and functions.
+When performing date operations on a date column, consider using appropriate PostgreSQL date functions for error redundancy.
+The table name will be provided in fully quoted form, with catalog and schema (if present). No need to add quotes.
+
+LANGUAGE:
+Any natural-language text in your response (e.g., the "description") must be in the same language as the user's question. If the language cannot be determined, default to English. SQL remains SQL.
+
+REATTEMPT:
+It's possible that your query will fail due to a SQL error or return an empty result set.
+If this happens, you will be provided the failed query and the error message.
+Take this failed SQL code and error message into consideration when building your query so that the problem doesn't happen again.
+""".strip()

--- a/utils/rest_api.py
+++ b/utils/rest_api.py
@@ -1667,7 +1667,7 @@ def get_available_external_data_stores(
     "/external-data-stores/{external_data_store_id}/external-data-sources/",
     responses={404: {"model": ExceptionBody}},
 )
-def register_external_data_sources(
+async def register_external_data_sources(
     request: Request,
     selected_datasource_ids: ExternalDataSourcesSelection,
     external_data_store_id: str,
@@ -1687,29 +1687,11 @@ def register_external_data_sources(
     Returns:
         ExternalDataStore: The updated data store
     """
-    return asyncio.run(
-        _register_external_data_sources_async(
-            request,
-            selected_datasource_ids,
-            external_data_store_id,
-            background_tasks,
-            analyst_db,
-        )
-    )
-
-
-async def _register_external_data_sources_async(
-    request: Request,
-    selected_datasource_ids: ExternalDataSourcesSelection,
-    external_data_store_id: str,
-    background_tasks: BackgroundTasks,
-    analyst_db: AnalystDB,
-) -> EmptyResponse:
     logger.debug(
         "PUT /external-data-stores/%s/external-data-sources/", external_data_store_id
     )
     with use_user_token(request):
-        name = DataSourceRecipe.get_canonical_name_for_datastore_id(
+        name = await DataSourceRecipe.get_canonical_name_for_datastore_id(
             external_data_store_id
         )
         if not name:


### PR DESCRIPTION
## 概要

upstream `datarobot-community/talk-to-my-data-agent` の `v0.3.21` タグ差分を取り込むPRです。

このPRは #57 (`v0.3.20`) の後続です。#57 が `dev` にマージされるまではGitHub上の差分が累積表示されます。レビュー順は #57 -> このPRです。

## 取り込み内容

- `.env.template`: database/remote datasource 周辺の設定更新
- `README.md`: upstreamドキュメント更新
- `app_frontend/src/components/chat/ErrorPanel.tsx`: 表示文言修正
- `app_frontend/src/i18n/locales/*`: i18n文言更新
- `pytest.ini`: remote datasource concurrency marker の追加
- `utils/api.py`, `utils/rest_api.py`, `utils/datarobot_dataset_handler.py`, `utils/prompts.py`: dataset handling とAPI周辺の upstream 修正

## 競合・補正

- 実マージでファイル競合はありませんでした。
- upstream追加の `pytest.ini` が既存 `pyproject.toml` の pytest 設定を上書きし、`app` import が壊れたため、既存設定を `pytest.ini` に統合しました。

## テスト

- `uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py`
  - 16 passed, 2 skipped
- `npm --prefix app_frontend test`
  - 103 passed
- `npm --prefix app_frontend run lint`
  - passed

## 注意

`pnpm --dir app_frontend test` / `lint` はローカルで pnpm lockfile 生成と build-script approval により実行前に停止しました。このリポジトリには `app_frontend/package-lock.json` があるため、frontend検証は npm で実施しています。
