### PR TITLE
[codex] Fix application source duplicate file paths

### DIFF
--- a/customize_docs/application_source_file_manifest.md
+++ b/customize_docs/application_source_file_manifest.md
@@ -1,0 +1,19 @@
+# Application Source file manifest
+
+## 背景
+
+GitHub Actions の Pulumi CD で、DataRobot `ApplicationSource` 更新時に `filePath` の重複で 422 が返った。
+
+`infra/settings_app_infra.py` の `get_app_files()` は `utils/**/*.py` で `utils/customize/**/*.py` も収集していたが、その後に `utils/customize/**/*.py` を同じ配置先パスで再追加していた。
+
+## 対応
+
+- `utils/customize/**/*.py` の二重追加を削除する。
+- Application Source に渡すファイル一覧の配置先パスを一意化する。
+- 同じ配置先に異なるローカルファイルが割り当てられた場合は、DataRobot API 送信前に `ValueError` で失敗させる。
+
+## テスト
+
+- `customize_docs/test_application_source_file_manifest.py`
+  - `get_app_files()` の返却する配置先パスに重複がないことを検証する。
+  - 今回ログに出た `utils/customize/api_endpoints/report.py` が 1 件だけ含まれることを検証する。

--- a/customize_docs/test_application_source_file_manifest.py
+++ b/customize_docs/test_application_source_file_manifest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from importlib import import_module
+from pathlib import Path
+from types import SimpleNamespace
+
+import pulumi_datarobot as datarobot
+
+
+def test_app_source_file_destinations_are_unique(monkeypatch) -> None:
+    monkeypatch.setenv("APP_ENVIRONMENT_ID", "test-env")
+    monkeypatch.syspath_prepend(str(Path(__file__).parents[1] / "infra"))
+    monkeypatch.setattr(
+        datarobot.ExecutionEnvironment,
+        "get",
+        staticmethod(
+            lambda id, resource_name: SimpleNamespace(id=id)  # noqa: A002
+        ),
+    )
+    sys.modules.pop("infra.settings_app_infra", None)
+
+    settings_app_infra = import_module("infra.settings_app_infra")
+    monkeypatch.setattr(
+        settings_app_infra,
+        "_prep_metadata_yaml",
+        lambda runtime_parameter_values: None,
+    )
+
+    destination_counts = Counter(
+        destination for _, destination in settings_app_infra.get_app_files([])
+    )
+    duplicate_destinations = sorted(
+        destination for destination, count in destination_counts.items() if count > 1
+    )
+
+    assert duplicate_destinations == []
+    assert destination_counts["utils/customize/api_endpoints/report.py"] == 1

--- a/infra/settings_app_infra.py
+++ b/infra/settings_app_infra.py
@@ -82,6 +82,29 @@ app_source_args = {
 app_resource_name: str = f"Data Analyst Application [{PROJECT_NAME}]"
 
 
+def _deduplicate_files_by_destination(
+    source_files: Sequence[Tuple[str, str]],
+) -> List[Tuple[str, str]]:
+    unique_files: dict[str, Tuple[str, str]] = {}
+    conflicting_destinations: set[str] = set()
+
+    for source_path, destination_path in source_files:
+        existing_file = unique_files.get(destination_path)
+        if existing_file is None:
+            unique_files[destination_path] = (source_path, destination_path)
+            continue
+        if existing_file[0] != source_path:
+            conflicting_destinations.add(destination_path)
+
+    if conflicting_destinations:
+        duplicates = ", ".join(sorted(conflicting_destinations))
+        raise ValueError(
+            f"Duplicate application source destination paths: {duplicates}"
+        )
+
+    return list(unique_files.values())
+
+
 def _prep_metadata_yaml(
     runtime_parameter_values: Sequence[
         datarobot.ApplicationSourceRuntimeParameterValueArgs
@@ -128,11 +151,6 @@ def get_app_files(
     utils_files = [
         (f.as_posix(), f.relative_to(PROJECT_ROOT).as_posix())
         for f in (PROJECT_ROOT / "utils").glob("**/*.py")
-        if f.is_file()
-    ]
-    utils_files += [
-        (str(f), f"utils/customize/{f.relative_to(PROJECT_ROOT / 'utils/customize')}")
-        for f in (PROJECT_ROOT / "utils/customize").glob("**/*.py")
         if f.is_file()
     ]
 
@@ -188,4 +206,4 @@ def get_app_files(
             )
         )
 
-    return source_files
+    return _deduplicate_files_by_destination(source_files)


### PR DESCRIPTION
## Summary

- Remove the duplicate utils/customize file collection from the DataRobot ApplicationSource manifest
- Deduplicate application source file destinations and fail early on conflicting destination paths
- Add regression coverage and customize_docs notes for the CD 422 duplicate filePath error

## Validation

- uv run ruff format --check infra/settings_app_infra.py customize_docs/test_application_source_file_manifest.py
- uv run ruff check infra/settings_app_infra.py customize_docs/test_application_source_file_manifest.py
- uv run pytest -c pytest.ini customize_docs/test_application_source_file_manifest.py -q
- uv run pytest -c pytest.ini app_backend/tests customize_docs/test_application_source_file_manifest.py -q
