### PR TITLE
[codex] Add v0.4.24 compatibility import layer

### DIFF
--- a/app_backend/tests/test_upstream_compat_imports.py
+++ b/app_backend/tests/test_upstream_compat_imports.py
@@ -1,0 +1,51 @@
+import importlib
+import inspect
+
+import pytest
+
+
+def _set_required_import_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "test-token")
+    monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://example.com")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+
+
+def test_database_helper_import_paths_remain_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_import_env(monkeypatch)
+
+    legacy = importlib.import_module("utils.database_helpers")
+    upstream_path = importlib.import_module(
+        "utils.data_connections.database.database_implementations"
+    )
+    schema = importlib.import_module("utils.schema")
+
+    assert upstream_path.DatabaseOperator is legacy.DatabaseOperator
+    assert upstream_path.NoDatabaseOperator is legacy.NoDatabaseOperator
+    assert "schema" in inspect.signature(upstream_path.get_external_database).parameters
+    assert "schema" in inspect.signature(upstream_path.get_database_operator).parameters
+
+    app_infra = schema.AppInfra(llm="no_llm", database="no_database")
+    operator = upstream_path.get_database_operator(app_infra)
+
+    assert isinstance(operator, legacy.NoDatabaseOperator)
+
+
+def test_datarobot_dataset_handler_import_paths_remain_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_import_env(monkeypatch)
+
+    legacy = importlib.import_module("utils.datarobot_dataset_handler")
+    upstream_path = importlib.import_module(
+        "utils.data_connections.datarobot.datarobot_dataset_handler"
+    )
+
+    for exported_name in (
+        "DataRobotOperator",
+        "DataSourceRecipe",
+        "DatasetSparkRecipe",
+    ):
+        assert hasattr(legacy, exported_name)
+        assert hasattr(upstream_path, exported_name)

--- a/customize_docs/upstream_sync_plan.md
+++ b/customize_docs/upstream_sync_plan.md
@@ -46,6 +46,6 @@
 
 ## `v0.4.24` の次アクション
 
-1. `utils/database_helpers.py` と `utils/datarobot_dataset_handler.py` の旧importを保ったまま、新しい data connection 層へ段階移行する。
+1. `utils/database_helpers.py` と `utils/datarobot_dataset_handler.py` の旧importを保ったまま、新しい data connection 層へ段階移行する。PR1では `utils.data_connections.database.database_implementations` を互換ファサードとして追加し、旧パス・新パスのimport回帰テストを追加する。
 2. `utils/api.py` と `utils/rest_api.py` は upstream 版を全面採用せず、既存カスタムAPIのcharacterization testを通しながら必要差分だけ移植する。
 3. Streamlit (`frontend/*`) は破棄方針のため、upstream同期では衝突解消せず別途削除・整理する。

--- a/utils/data_connections/database/database_implementations.py
+++ b/utils/data_connections/database/database_implementations.py
@@ -1,0 +1,55 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+from utils.database_helpers import (
+    BigQueryOperator,
+    DatabaseOperator,
+    NoDatabaseOperator,
+    SAPDatasphereOperator,
+    SnowflakeOperator,
+    load_app_infra,
+)
+from utils.database_helpers import (
+    get_database_operator as _get_database_operator,
+)
+from utils.database_helpers import (
+    get_external_database as _get_external_database,
+)
+from utils.schema import AppInfra
+
+
+def get_database_operator(
+    app_infra: AppInfra, schema: str | None = None
+) -> DatabaseOperator[Any]:
+    return _get_database_operator(app_infra, schema=schema)
+
+
+def get_external_database(schema: str | None = None) -> DatabaseOperator[Any]:
+    return _get_external_database(schema=schema)
+
+
+__all__ = [
+    "BigQueryOperator",
+    "DatabaseOperator",
+    "NoDatabaseOperator",
+    "SAPDatasphereOperator",
+    "SnowflakeOperator",
+    "get_database_operator",
+    "get_external_database",
+    "load_app_infra",
+]


### PR DESCRIPTION
## Summary

- Add `utils.data_connections.database.database_implementations` as a compatibility facade over the existing `utils.database_helpers` implementation.
- Keep legacy import paths for `utils.database_helpers` and `utils.datarobot_dataset_handler` intact.
- Add import regression coverage so future v0.4.24 migration work does not delete the legacy paths prematurely.
- Record the PR1 direction in `customize_docs/upstream_sync_plan.md`.

## Scope

This PR intentionally does not migrate `utils/api.py`, `utils/rest_api.py`, `utils/analyst_db.py`, or Streamlit files. It is only the import compatibility layer for the next upstream sync step.

## Validation

- `uv run pytest app_backend/tests/test_upstream_compat_imports.py`: 2 passed
- `uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py`: 18 passed, 2 skipped
- `uv run ruff check app_backend/tests/test_upstream_compat_imports.py utils/data_connections/database/database_implementations.py`: passed
