### PR TITLE
PR3: Port safe rest API v0.4.24 endpoint updates

### DIFF
--- a/app_backend/pyproject.toml
+++ b/app_backend/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
     "langid==1.1.6",
     "pillow==11.3.0",
     "babel>=2.16,<3",
+    "chardet>=5.0.0,<6.0",
 ]
 
 [project.optional-dependencies]

--- a/app_backend/tests/test_rest_api_v0424_compat.py
+++ b/app_backend/tests/test_rest_api_v0424_compat.py
@@ -1,0 +1,188 @@
+import asyncio
+import io
+import os
+
+import pandas as pd
+import pytest
+from fastapi import BackgroundTasks, UploadFile
+
+os.environ.setdefault("DATAROBOT_API_TOKEN", "test-token")
+os.environ.setdefault("DATAROBOT_ENDPOINT", "https://example.com")
+os.environ.setdefault("OTEL_SDK_DISABLED", "true")
+
+from utils import rest_api
+from utils.analyst_db import InternalDataSourceType
+from utils.schema import AnalystDataset, LoadDatabaseRequest
+
+
+def test_csv_helpers_decode_bom_and_load_pandas_dataframe() -> None:
+    raw_bytes = "\ufeffdate;amount\r\n2026-01-01;100\r\n".encode()
+
+    decoded = rest_api.detect_and_decode_csv(raw_bytes, "sales.csv")
+    dataframe = rest_api.load_and_validate_csv(decoded, "sales.csv")
+
+    assert decoded.startswith("date;amount")
+    assert isinstance(dataframe, pd.DataFrame)
+    assert dataframe.to_dict("records") == [
+        {"date": "2026-01-01", "amount": 100},
+    ]
+
+
+def test_csv_loader_rejects_header_only_file() -> None:
+    with pytest.raises(ValueError, match="contains only headers"):
+        rest_api.load_and_validate_csv("date,amount\n", "empty.csv")
+
+
+def test_upload_files_registers_csv_as_pandas_dataframe() -> None:
+    asyncio.run(_assert_upload_files_registers_csv_as_pandas_dataframe())
+
+
+async def _assert_upload_files_registers_csv_as_pandas_dataframe() -> None:
+    class FakeAnalystDB:
+        def __init__(self) -> None:
+            self.registered: list[tuple[AnalystDataset, InternalDataSourceType]] = []
+
+        async def register_dataset(
+            self,
+            dataset: AnalystDataset,
+            data_source: InternalDataSourceType,
+            file_size: int = 0,
+        ) -> dict[str, object]:
+            self.registered.append((dataset, data_source))
+            return {"success": True, "msg": ""}
+
+    raw_bytes = "\ufeffdate;amount\r\n2026-01-01;100\r\n".encode()
+    upload_file = UploadFile(
+        filename="sales.csv",
+        file=io.BytesIO(raw_bytes),
+        size=len(raw_bytes),
+    )
+    analyst_db = FakeAnalystDB()
+
+    response = await rest_api.upload_files(
+        request=object(),  # type: ignore[arg-type]
+        background_tasks=BackgroundTasks(),
+        analyst_db=analyst_db,  # type: ignore[arg-type]
+        files=[upload_file],
+        registry_ids=None,
+    )
+
+    assert response == [
+        {
+            "filename": "sales.csv",
+            "content_type": None,
+            "size": len(raw_bytes),
+            "dataset_name": "sales",
+        }
+    ]
+    registered_dataset, data_source = analyst_db.registered[0]
+    assert data_source is InternalDataSourceType.FILE
+    assert isinstance(registered_dataset.to_df(), pd.DataFrame)
+    assert registered_dataset.to_df().to_dict("records") == [
+        {"date": "2026-01-01", "amount": 100},
+    ]
+
+
+def test_load_from_database_registers_placeholders_and_defers_processing() -> None:
+    asyncio.run(_assert_load_from_database_registers_placeholders())
+
+
+async def _assert_load_from_database_registers_placeholders() -> None:
+    class FakeAnalystDB:
+        def __init__(self) -> None:
+            self.registered: list[tuple[AnalystDataset, InternalDataSourceType]] = []
+
+        async def register_dataset(
+            self,
+            dataset: AnalystDataset,
+            data_source: InternalDataSourceType,
+        ) -> dict[str, object]:
+            self.registered.append((dataset, data_source))
+            return {"success": True, "msg": ""}
+
+    analyst_db = FakeAnalystDB()
+    background_tasks = BackgroundTasks()
+
+    result = await rest_api.load_from_database(
+        LoadDatabaseRequest(table_names=["sales", "customers"], schema_name="PUBLIC"),
+        background_tasks,
+        analyst_db,  # type: ignore[arg-type]
+    )
+
+    assert result == ["sales", "customers"]
+    assert [
+        (dataset.name, isinstance(dataset.to_df(), pd.DataFrame), dataset.to_df().empty)
+        for dataset, data_source in analyst_db.registered
+        if data_source is InternalDataSourceType.DATABASE
+    ] == [
+        ("sales", True, True),
+        ("customers", True, True),
+    ]
+    assert len(background_tasks.tasks) == 1
+    background_task = background_tasks.tasks[0]
+    assert background_task.func is rest_api.get_and_process_tables
+    assert background_task.args == (
+        ["sales", "customers"],
+        analyst_db,
+        1_000,
+        "PUBLIC",
+    )
+
+
+def test_get_and_process_tables_uses_schema_and_processes_loaded_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asyncio.run(_assert_get_and_process_tables_uses_schema(monkeypatch))
+
+
+async def _assert_get_and_process_tables_uses_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, object] = {}
+    analyst_db = object()
+
+    class FakeDatabaseOperator:
+        async def get_data(
+            self,
+            *table_names: str,
+            analyst_db: object,
+            sample_size: int,
+        ) -> list[str]:
+            calls["get_data"] = {
+                "table_names": table_names,
+                "analyst_db": analyst_db,
+                "sample_size": sample_size,
+            }
+            return ["sales", "customers"]
+
+    def fake_get_external_database(schema: str | None = None) -> FakeDatabaseOperator:
+        calls["schema"] = schema
+        return FakeDatabaseOperator()
+
+    async def fake_process_and_update(
+        dataset_names: list[str],
+        analyst_db: object,
+        datasource_type: InternalDataSourceType,
+    ) -> None:
+        calls["process"] = {
+            "dataset_names": dataset_names,
+            "analyst_db": analyst_db,
+            "datasource_type": datasource_type,
+        }
+
+    monkeypatch.setattr(rest_api, "get_external_database", fake_get_external_database)
+    monkeypatch.setattr(rest_api, "process_and_update", fake_process_and_update)
+
+    await rest_api.get_and_process_tables(["raw_sales"], analyst_db, 25, "PUBLIC")
+
+    assert calls["schema"] == "PUBLIC"
+    assert calls["get_data"] == {
+        "table_names": ("raw_sales",),
+        "analyst_db": analyst_db,
+        "sample_size": 25,
+    }
+    assert calls["process"] == {
+        "dataset_names": ["sales", "customers"],
+        "analyst_db": analyst_db,
+        "datasource_type": InternalDataSourceType.DATABASE,
+    }

--- a/customize_docs/upstream_sync_plan.md
+++ b/customize_docs/upstream_sync_plan.md
@@ -48,8 +48,9 @@
 
 1. `utils/database_helpers.py` と `utils/datarobot_dataset_handler.py` の旧importを保ったまま、新しい data connection 層へ段階移行する。PR1では `utils.data_connections.database.database_implementations` を互換ファサードとして追加し、旧パス・新パスのimport回帰テストを追加する。
 2. PR2では `analyst_db.py` の `DatasetMetadata` モデル化、保存時ロック、メタデータJSON decode、ログ/例外処理の小差分を移植する。pandas前提は維持し、upstreamのpandas→polars差分は取り込まない。
-3. `utils/api.py` と `utils/rest_api.py` は upstream 版を全面採用せず、既存カスタムAPIのcharacterization testを通しながら必要差分だけ移植する。
-4. Streamlit (`frontend/*`) は破棄方針のため、upstream同期では衝突解消せず別途削除・整理する。
+3. PR3では `utils/rest_api.py` のCSV decode/validationとdatabase endpointのbackground化を移植する。pandas前提は維持し、CSV loaderは `pd.DataFrame` を返す。
+4. `utils/api.py` と `utils/rest_api.py` の残り差分は upstream 版を全面採用せず、既存カスタムAPIのcharacterization testを通しながら必要差分だけ移植する。
+5. Streamlit (`frontend/*`) は破棄方針のため、upstream同期では衝突解消せず別途削除・整理する。
 
 ## PR2 CI対応メモ
 
@@ -58,3 +59,9 @@
 - 追加でPython 3.11のCIにより、`str in Enum` が `TypeError` になる互換性問題を検出。`get_data_source_type()` は `Enum(value)` 変換と `ValueError` 捕捉に変更し、Python 3.10/3.11/3.12で同じ挙動にする。
 - 2026-06-07: upstream `v0.4.24` の残り小差分から、`_save_to_storage()` 簡略化、`get_dataframe()` debugログ化、`register_dataset()` の `exc_info=True`、`get_data_dictionary()` の `ValueError` 分離を追加移植。`register_dataset()` の成功/失敗dict返却とpandas DataFrame返却は維持する。
 - pandas前提の回帰確認は維持する。pandas→polars差分は引き続き取り込まない。
+
+## PR3 実装メモ
+
+- 2026-06-07: `utils/rest_api.py` にCSVのencoding検出、UTF-8 BOM除去、delimiter検出、header-only CSVの検証を追加。upstreamはpolars loaderだが、このリポジトリでは `pd.read_csv` を使い `pd.DataFrame` を返す。
+- `/database/select` は選択table名を即時返し、空のpandas datasetを `InternalDataSourceType.DATABASE` として登録してから、実データ取得と cleansing/dictionary 生成をbackground taskへ移す。schema指定は既存仕様を維持する。
+- `chardet` は既にrequirementsにあるが、CIのbackend testは `app_backend/pyproject.toml` から `uv sync` するため、同ファイルにも依存を追加する。

--- a/utils/rest_api.py
+++ b/utils/rest_api.py
@@ -25,6 +25,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Iterable, List, Union, cast
 
+import chardet
 import datarobot as dr
 import pandas as pd
 from fastapi import (
@@ -117,6 +118,100 @@ from utils.token_tracking import (
 logger = get_logger()
 
 MAX_EXCEL_ROWS = 50000  # Maximum rows to export to Excel to prevent memory issues
+
+
+def detect_and_decode_csv(raw_bytes: bytes, filename: str) -> str:
+    """
+    Detect encoding and decode CSV content with UTF-8 BOM handling.
+
+    Raises ValueError with a descriptive message when decoding fails.
+    """
+    if raw_bytes.startswith(b"\xef\xbb\xbf"):
+        logger.info(f"Stripped UTF-8 BOM from '{filename}'")
+        raw_bytes = raw_bytes[3:]
+
+    if not raw_bytes:
+        raise ValueError(f"File '{filename}' is empty or could not be read.")
+
+    detection_result = chardet.detect(raw_bytes)
+    detected_encoding = detection_result.get("encoding")
+    confidence = detection_result.get("confidence") or 0
+
+    if detected_encoding:
+        logger.info(
+            f"Detected encoding for '{filename}': {detected_encoding} "
+            f"(confidence: {confidence:.2f})"
+        )
+
+    encodings_to_try: list[str] = []
+    if detected_encoding and confidence >= 0.7:
+        encodings_to_try.append(detected_encoding)
+    encodings_to_try.extend(["utf-8", "cp932", "shift_jis"])
+
+    tried: set[str] = set()
+    for encoding in encodings_to_try:
+        normalized_encoding = encoding.lower()
+        if normalized_encoding in tried:
+            continue
+        tried.add(normalized_encoding)
+        try:
+            return raw_bytes.decode(encoding)
+        except (UnicodeDecodeError, LookupError) as e:
+            logger.debug(f"Failed to decode '{filename}' with encoding {encoding}: {e}")
+
+    raise ValueError(
+        f"Unable to decode file '{filename}'. All encoding attempts failed."
+    )
+
+
+def detect_delimiter(content: str) -> str:
+    """Detect a CSV delimiter from the first few lines, defaulting to comma."""
+    lines = content.split("\n")[:5]
+    delimiters = {",": 0, ";": 0, "\t": 0, "|": 0}
+
+    for line in lines:
+        if not line.strip():
+            continue
+        for delimiter in delimiters:
+            delimiters[delimiter] += line.count(delimiter)
+
+    best_delimiter = max(delimiters, key=lambda delimiter: delimiters[delimiter])
+    return best_delimiter if delimiters[best_delimiter] > 0 else ","
+
+
+def load_and_validate_csv(decoded_content: str, filename: str) -> pd.DataFrame:
+    """
+    Parse CSV content into a pandas DataFrame and validate that rows are present.
+
+    Raises ValueError with a descriptive message on parse or validation failure.
+    """
+    if "\r" in decoded_content:
+        decoded_content = decoded_content.replace("\r\n", "\n").replace("\r", "\n")
+
+    separator = detect_delimiter(decoded_content)
+    if separator != ",":
+        logger.info(f"Detected delimiter '{separator}' for '{filename}'")
+
+    try:
+        dataframe = pd.read_csv(io.StringIO(decoded_content), sep=separator)
+    except pd.errors.EmptyDataError as e:
+        raise ValueError(f"CSV file '{filename}' is empty.") from e
+    except pd.errors.ParserError as e:
+        raise ValueError(f"Unable to parse CSV file '{filename}'. Error: {e}") from e
+
+    if dataframe.empty:
+        raise ValueError(f"CSV file '{filename}' contains only headers, no data rows.")
+
+    lines = [line for line in decoded_content.split("\n") if line.strip()]
+    if len(lines) > 1:
+        expected_rows = len(lines) - 1
+        if len(dataframe) < expected_rows * 0.9:
+            logger.warning(
+                f"CSV file '{filename}' had inconsistent row lengths. "
+                f"Expected ~{expected_rows} rows, got {len(dataframe)}."
+            )
+
+    return dataframe
 
 
 def _chart_trace_to_dataframe(trace: dict[str, Any]) -> pd.DataFrame:
@@ -510,9 +605,18 @@ async def upload_files(
                 if file_extension == ".csv":
                     logger.info(f"Loading CSV: {file.filename}")
                     log_memory()
-                    df = pd.read_csv(
-                        io.StringIO(contents.decode("utf-8")),
-                    )
+                    try:
+                        decoded_content = detect_and_decode_csv(contents, file.filename)
+                        df = load_and_validate_csv(decoded_content, file.filename)
+                    except ValueError as e:
+                        raise HTTPException(status_code=400, detail=str(e)) from e
+                    except Exception as e:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                f"Failed to read CSV file '{file.filename}': {str(e)}"
+                            ),
+                        ) from e
                     log_memory()
                     dataset_name = os.path.splitext(file.filename)[0]
                     dataset = AnalystDataset(name=dataset_name, data=df)
@@ -546,9 +650,18 @@ async def upload_files(
 
                 elif file_extension in [".xlsx", ".xls"]:
                     base_name = os.path.splitext(file.filename)[0]
-                    excel_dataset = pd.read_excel(
-                        io.BytesIO(contents), sheet_name=None
-                    )  # Get available sheet names
+                    try:
+                        excel_dataset = pd.read_excel(
+                            io.BytesIO(contents), sheet_name=None
+                        )
+                    except Exception as e:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                f"Unable to read Excel file '{file.filename}'. "
+                                f"Error: {str(e)}"
+                            ),
+                        ) from e
                     if isinstance(excel_dataset, dict):
                         for sheet_name, data in excel_dataset.items():
                             dataset_name = f"{base_name}_{sheet_name}"
@@ -656,27 +769,42 @@ async def load_from_database(
     data: LoadDatabaseRequest,
     background_tasks: BackgroundTasks,
     analyst_db: AnalystDB = Depends(get_initialized_db),
-    sample_size: int = 5000,
+    sample_size: int = 1_000,
 ) -> list[str]:
-    dataset_names = []
+    await asyncio.gather(
+        *[
+            analyst_db.register_dataset(
+                AnalystDataset(name=table_name),
+                InternalDataSourceType.DATABASE,
+            )
+            for table_name in data.table_names
+        ]
+    )
 
-    # Load the data from the database
     if data.table_names:
-        dataframes = await get_external_database(schema=data.schema_name).get_data(
-            *data.table_names, analyst_db=analyst_db, sample_size=sample_size
-        )
-        dataset_names.extend(dataframes)
-
-    # Process the data in the background (cleansing and dictionary generation)
-    if dataset_names:
         background_tasks.add_task(
-            process_and_update,
-            dataset_names,
+            get_and_process_tables,
+            data.table_names,
             analyst_db,
-            InternalDataSourceType.DATABASE,
+            sample_size,
+            data.schema_name,
         )
 
-    return dataset_names
+    return data.table_names
+
+
+async def get_and_process_tables(
+    table_names: list[str],
+    analyst_db: AnalystDB,
+    sample_size: int,
+    schema_name: str | None = None,
+) -> None:
+    dataset_names = await get_external_database(schema=schema_name).get_data(
+        *table_names,
+        analyst_db=analyst_db,
+        sample_size=sample_size,
+    )
+    await process_and_update(dataset_names, analyst_db, InternalDataSourceType.DATABASE)
 
 
 @router.get("/dictionaries")


### PR DESCRIPTION
## Summary
- Port the safe `utils/rest_api.py` CSV/database endpoint changes from upstream v0.4.24 without adopting upstream polars CSV loading.
- Add pandas-based CSV encoding detection, BOM stripping, delimiter detection, and header-only validation.
- Change `/database/select` to register placeholder pandas datasets immediately and defer database fetch + cleansing/dictionary processing to a background task while preserving schema selection.
- Add `chardet` to `app_backend/pyproject.toml` because backend CI runs `uv sync` from that project.
- Record the PR3 scope in `customize_docs/upstream_sync_plan.md`.

## Pandas constraint
- CSV loading continues to use `pd.read_csv`.
- Tests assert uploaded CSVs and database placeholders are pandas-backed `AnalystDataset` objects.

## Validation
- `uv run pytest app_backend/tests/test_rest_api_v0424_compat.py`
- `uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `cd app_backend && uv run --extra dev --python 3.10 pytest tests/test_rest_api_v0424_compat.py`
- `cd app_backend && uv run --extra dev --python 3.11 pytest tests/test_rest_api_v0424_compat.py`
- `cd app_backend && uv run --extra dev --python 3.12 pytest tests/test_rest_api_v0424_compat.py`