### PR TITLE
PR4: Port v0.4.24 analysis execution step updates

### DIFF
--- a/app_backend/tests/test_api_analysis_execution_v0424_compat.py
+++ b/app_backend/tests/test_api_analysis_execution_v0424_compat.py
@@ -1,0 +1,171 @@
+import asyncio
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import pandas as pd
+
+os.environ.setdefault("DATAROBOT_API_TOKEN", "test-token")
+os.environ.setdefault("DATAROBOT_ENDPOINT", "https://example.com")
+os.environ.setdefault("OTEL_SDK_DISABLED", "true")
+
+from utils import api
+from utils.analyst_db import DatasetMetadata, DatasetType, InternalDataSourceType
+from utils.credentials import NoDatabaseCredentials
+from utils.database_helpers import NoDatabaseOperator
+from utils.schema import (
+    AnalystChatMessage,
+    AnalystDataset,
+    ChatRequest,
+    RunAnalysisRequest,
+)
+from utils.token_tracking import TiktokenCountingStrategy, TokenUsageTracker
+
+
+def _dataset_metadata(name: str) -> DatasetMetadata:
+    return DatasetMetadata(
+        name=name,
+        external_id=None,
+        dataset_type=DatasetType.STANDARD,
+        original_name=name,
+        created_at=datetime(2026, 6, 7, tzinfo=timezone.utc),
+        columns=["amount"],
+        original_column_types=None,
+        row_count=2,
+        data_source=InternalDataSourceType.FILE,
+    )
+
+
+def _analysis_context(analyst_db: Any) -> api.RunCompleteAnalysisRequestContext:
+    context = api.RunCompleteAnalysisRequestContext(
+        chat_request=ChatRequest(messages=[{"role": "user", "content": "sum amount"}]),
+        request=None,
+        data_source=InternalDataSourceType.FILE,
+        dataset_metadata=[_dataset_metadata("sales")],
+        analyst_db=analyst_db,
+        chat_id="chat-1",
+        user_message_id="user-1",
+        enable_chart_generation=False,
+        enable_business_insights=False,
+        token_tracker=TokenUsageTracker(strategy=TiktokenCountingStrategy()),
+    )
+    context.assistant_message_id = "assistant-1"
+    context.assistant_message = AnalystChatMessage(
+        role="assistant",
+        content="",
+        components=[],
+        in_progress=True,
+    )
+    return context
+
+
+def test_stage_message_update_persists_ordered_message_snapshots() -> None:
+    asyncio.run(_assert_stage_message_update_persists_ordered_snapshots())
+
+
+async def _assert_stage_message_update_persists_ordered_snapshots() -> None:
+    class FakeAnalystDB:
+        def __init__(self) -> None:
+            self.updates: list[AnalystChatMessage] = []
+
+        async def update_chat_message(
+            self, message_id: str, message: AnalystChatMessage
+        ) -> None:
+            await asyncio.sleep(0)
+            assert message_id == "assistant-1"
+            self.updates.append(message.model_copy(deep=True))
+
+    analyst_db = FakeAnalystDB()
+    context = _analysis_context(analyst_db)
+
+    assert context.assistant_message is not None
+    context.assistant_message.step_value = "GENERATING_QUERY"
+    context.stage_message_update()
+    context.assistant_message.step_value = "RUNNING_QUERY"
+    context.stage_message_update()
+
+    await context.await_message_update()
+
+    assert [message.step_value for message in analyst_db.updates] == [
+        "GENERATING_QUERY",
+        "RUNNING_QUERY",
+    ]
+
+
+def test_run_analysis_updates_execution_steps_and_preserves_pandas(
+    monkeypatch,
+) -> None:
+    asyncio.run(_assert_run_analysis_updates_steps_and_preserves_pandas(monkeypatch))
+
+
+async def _assert_run_analysis_updates_steps_and_preserves_pandas(monkeypatch) -> None:
+    class FakeAnalystDB:
+        def __init__(self) -> None:
+            self.updates: list[AnalystChatMessage] = []
+
+        async def update_chat_message(
+            self, message_id: str, message: AnalystChatMessage
+        ) -> None:
+            assert message_id == "assistant-1"
+            self.updates.append(message.model_copy(deep=True))
+
+        async def get_cleansed_dataset(
+            self, dataset_name: str, max_rows: int | None = None
+        ) -> AnalystDataset:
+            raise ValueError("no cleansed dataset")
+
+        async def get_dataset(
+            self, dataset_name: str, max_rows: int | None = None
+        ) -> AnalystDataset:
+            assert dataset_name == "sales"
+            assert max_rows is None
+            return AnalystDataset(
+                name="sales",
+                data=pd.DataFrame({"amount": [100, 200]}),
+            )
+
+    async def fake_generate_run_analysis_python_code(*args, **kwargs) -> str:
+        return "def analyze_data(datasets): ..."
+
+    def fake_execute_python(**kwargs) -> AnalystDataset:
+        assert "pl" not in kwargs["modules"]
+        assert "polars" not in kwargs["allowed_modules"]
+        input_data = kwargs["input_data"]
+        assert isinstance(input_data["sales"], pd.DataFrame)
+        return AnalystDataset(
+            name="analysis_result",
+            data=pd.DataFrame({"total_amount": [300]}),
+        )
+
+    monkeypatch.setattr(
+        api,
+        "_generate_run_analysis_python_code",
+        fake_generate_run_analysis_python_code,
+    )
+    monkeypatch.setattr(api, "execute_python", fake_execute_python)
+
+    analyst_db = FakeAnalystDB()
+    context = _analysis_context(analyst_db)
+
+    result = await api.run_analysis(
+        RunAnalysisRequest(dataset_names=["sales"], question="sum amount"),
+        analysis_context=context,
+    )
+
+    await context.await_message_update()
+
+    assert result.status == "success"
+    assert result.dataset is not None
+    assert isinstance(result.dataset.to_df(), pd.DataFrame)
+    assert result.dataset.to_df().to_dict("records") == [{"total_amount": 300}]
+    assert [message.step_value for message in analyst_db.updates] == [
+        "GENERATING_QUERY",
+        "RUNNING_QUERY",
+    ]
+
+
+def test_no_database_operator_supports_noop_warmup() -> None:
+    operator = NoDatabaseOperator(NoDatabaseCredentials())
+
+    assert operator.warmup_query() is None
+    assert asyncio.run(operator.warmup()) is None

--- a/app_backend/tests/test_api_analysis_execution_v0424_compat.py
+++ b/app_backend/tests/test_api_analysis_execution_v0424_compat.py
@@ -18,6 +18,8 @@ from utils.schema import (
     AnalystDataset,
     ChatRequest,
     RunAnalysisRequest,
+    RunAnalysisResult,
+    RunAnalysisResultMetadata,
 )
 from utils.token_tracking import TiktokenCountingStrategy, TokenUsageTracker
 
@@ -169,3 +171,105 @@ def test_no_database_operator_supports_noop_warmup() -> None:
 
     assert operator.warmup_query() is None
     assert asyncio.run(operator.warmup()) is None
+
+
+def test_run_complete_analysis_passes_tracker_and_telemetry_to_run_analysis(
+    monkeypatch,
+) -> None:
+    asyncio.run(
+        _assert_run_complete_analysis_passes_tracker_and_telemetry_to_run_analysis(
+            monkeypatch
+        )
+    )
+
+
+async def _assert_run_complete_analysis_passes_tracker_and_telemetry_to_run_analysis(
+    monkeypatch,
+) -> None:
+    class FakeAnalystDB:
+        def __init__(self) -> None:
+            self.user_message = AnalystChatMessage(
+                id="user-1",
+                role="user",
+                content="sum amount",
+                components=[],
+                in_progress=True,
+            )
+            self.updates: list[AnalystChatMessage] = []
+
+        async def get_chat_message(self, message_id: str) -> AnalystChatMessage | None:
+            if message_id == "user-1":
+                return self.user_message
+            return None
+
+        async def add_chat_message(
+            self, chat_id: str, message: AnalystChatMessage
+        ) -> str:
+            assert chat_id == "chat-1"
+            message.id = "assistant-1"
+            return message.id
+
+        async def update_chat_message(
+            self, message_id: str, message: AnalystChatMessage
+        ) -> None:
+            self.updates.append(message.model_copy(deep=True))
+
+    telemetry_json = {"request_id": "telemetry-1"}
+    run_analysis_kwargs: dict[str, Any] = {}
+
+    async def fake_rephrase_message(*args, **kwargs) -> str:
+        return "enhanced question"
+
+    async def fake_run_analysis(*args, **kwargs) -> RunAnalysisResult:
+        run_analysis_kwargs.update(kwargs)
+        return RunAnalysisResult(
+            status="success",
+            dataset=AnalystDataset(
+                name="analysis_result",
+                data=pd.DataFrame({"total_amount": [300]}),
+            ),
+            metadata=RunAnalysisResultMetadata(
+                duration=0,
+                attempts=1,
+                datasets_analyzed=1,
+            ),
+        )
+
+    async def fake_extract_and_store_datasets(
+        analyst_db: FakeAnalystDB,
+        assistant_message: AnalystChatMessage,
+    ) -> AnalystChatMessage:
+        return assistant_message
+
+    monkeypatch.setattr(api, "rephrase_message", fake_rephrase_message)
+    monkeypatch.setattr(api, "run_analysis", fake_run_analysis)
+    monkeypatch.setattr(
+        api, "extract_and_store_datasets", fake_extract_and_store_datasets
+    )
+
+    results = [
+        component
+        async for component in api.run_complete_analysis(
+            chat_request=ChatRequest(
+                messages=[{"role": "user", "content": "sum amount"}]
+            ),
+            data_source=InternalDataSourceType.FILE,
+            dataset_metadata=[_dataset_metadata("sales")],
+            analyst_db=FakeAnalystDB(),  # type: ignore[arg-type]
+            chat_id="chat-1",
+            message_id="user-1",
+            request=None,
+            enable_chart_generation=False,
+            enable_business_insights=False,
+            telemetry_json=telemetry_json,
+        )
+    ]
+
+    assert results[0] == "enhanced question"
+    assert isinstance(results[1], RunAnalysisResult)
+    assert run_analysis_kwargs["telemetry_json"] is telemetry_json
+    assert run_analysis_kwargs["token_tracker"] is not None
+    assert (
+        run_analysis_kwargs["token_tracker"]
+        is run_analysis_kwargs["analysis_context"].token_tracker
+    )

--- a/customize_docs/upstream_sync_plan.md
+++ b/customize_docs/upstream_sync_plan.md
@@ -49,8 +49,9 @@
 1. `utils/database_helpers.py` と `utils/datarobot_dataset_handler.py` の旧importを保ったまま、新しい data connection 層へ段階移行する。PR1では `utils.data_connections.database.database_implementations` を互換ファサードとして追加し、旧パス・新パスのimport回帰テストを追加する。
 2. PR2では `analyst_db.py` の `DatasetMetadata` モデル化、保存時ロック、メタデータJSON decode、ログ/例外処理の小差分を移植する。pandas前提は維持し、upstreamのpandas→polars差分は取り込まない。
 3. PR3では `utils/rest_api.py` のCSV decode/validationとdatabase endpointのbackground化を移植する。pandas前提は維持し、CSV loaderは `pd.DataFrame` を返す。
-4. `utils/api.py` と `utils/rest_api.py` の残り差分は upstream 版を全面採用せず、既存カスタムAPIのcharacterization testを通しながら必要差分だけ移植する。
-5. Streamlit (`frontend/*`) は破棄方針のため、upstream同期では衝突解消せず別途削除・整理する。
+4. PR4では `utils/api.py` の分析実行まわりから、`RunCompleteAnalysisRequestContext` と分析step更新 (`GENERATING_QUERY` / `RUNNING_QUERY`) を移植する。pandas前提は維持し、upstreamの `polars` allowed module追加や `pd.DataFrame` 置換は取り込まない。
+5. PR5では `utils/api.py` のLLM応答validation/error handling差分を小さく移植する。チャート生成、ビジネス分析、database SQL生成で `ValidationError` をユーザー向けの `AnalysisError` に変換する。
+6. Streamlit (`frontend/*`) は破棄方針のため、upstream同期では衝突解消せず別途削除・整理する。
 
 ## PR2 CI対応メモ
 
@@ -65,3 +66,11 @@
 - 2026-06-07: `utils/rest_api.py` にCSVのencoding検出、UTF-8 BOM除去、delimiter検出、header-only CSVの検証を追加。upstreamはpolars loaderだが、このリポジトリでは `pd.read_csv` を使い `pd.DataFrame` を返す。
 - `/database/select` は選択table名を即時返し、空のpandas datasetを `InternalDataSourceType.DATABASE` として登録してから、実データ取得と cleansing/dictionary 生成をbackground taskへ移す。schema指定は既存仕様を維持する。
 - `chardet` は既にrequirementsにあるが、CIのbackend testは `app_backend/pyproject.toml` から `uv sync` するため、同ファイルにも依存を追加する。
+
+## PR4 実装メモ
+
+- 2026-06-07: `utils/api.py` に `RunCompleteAnalysisRequestContext` を追加し、assistant/user message更新を順序付きbackground taskとしてstageできるようにする。保存前に message と step を浅くコピーし、後続のstep変更で先に積んだ更新内容が変わらないようにする。
+- ローカル分析の `_run_analysis()` / `run_analysis()` は新しいcontext経由でも呼べるようにし、コード生成前に `GENERATING_QUERY`、Python実行前に `RUNNING_QUERY` を保存する。既存の `analyst_db` / `token_tracker` 引数の呼び出し互換は残す。
+- `run_complete_analysis()` はローカル分析経路でcontextを渡す。既存のpandas DataFrame入力、`execute_python` の allowed modules、`AnalystDataset.to_df()` は維持する。
+- legacy `utils.database_helpers.DatabaseOperator` に no-op `warmup_query()` / `warmup()` を追加し、upstreamの接続テスト呼び出しに備える。DB実装階層や `utils.data_connections` への全面差し替えはしない。
+- 追加テスト: `app_backend/tests/test_api_analysis_execution_v0424_compat.py`。staged updateの順序、`run_analysis` のstep更新、pandas DataFrame維持、no-op warmupを検証する。

--- a/utils/api.py
+++ b/utils/api.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import copy
 import functools
 import inspect
 import json
@@ -30,6 +31,7 @@ from typing import (
     Any,
     AsyncGenerator,
     Callable,
+    Literal,
     TypeVar,
     cast,
 )
@@ -1464,12 +1466,20 @@ async def get_business_analysis(
 @telemetry.trace
 async def _run_analysis(
     request: RunAnalysisRequest,
-    analyst_db: AnalystDB,
+    analyst_db: AnalystDB | None = None,
     exception_history: list[InvalidGeneratedCode] | None = None,
     token_tracker: TokenUsageTracker | None = None,
     telemetry_json: dict[str, Any] | None = None,
+    analysis_context: RunCompleteAnalysisRequestContext | None = None,
 ) -> RunAnalysisResult:
     start_time = datetime.now()
+
+    if analysis_context:
+        analyst_db = analysis_context.analyst_db
+        token_tracker = analysis_context.token_tracker
+
+    if analyst_db is None:
+        raise ValueError("analyst_db is required")
 
     if not request.dataset_names:
         raise ValueError(VALUE_ERROR_MESSAGE)
@@ -1477,6 +1487,16 @@ async def _run_analysis(
     if exception_history is None:
         exception_history = []
     logger.info(f"Running analysis (attempt {len(exception_history)})")
+
+    if (
+        analysis_context
+        and analysis_context.assistant_message_id
+        and analysis_context.assistant_message
+    ):
+        analysis_context.assistant_message.step_value = "GENERATING_QUERY"
+        analysis_context.assistant_message.step_reattempt = len(exception_history)
+        analysis_context.stage_message_update()
+
     code = await _generate_run_analysis_python_code(
         request,
         analyst_db,
@@ -1486,6 +1506,16 @@ async def _run_analysis(
         telemetry_json=telemetry_json,
     )
     logger.info("Code generated, preparing execution")
+
+    if (
+        analysis_context
+        and analysis_context.assistant_message_id
+        and analysis_context.assistant_message
+    ):
+        analysis_context.assistant_message.step_value = "RUNNING_QUERY"
+        analysis_context.assistant_message.step_reattempt = len(exception_history)
+        analysis_context.stage_message_update()
+
     dataframes: dict[str, pd.DataFrame] = {}
 
     for dataset_name in request.dataset_names:
@@ -1554,9 +1584,10 @@ async def _run_analysis(
 @log_api_call
 async def run_analysis(
     request: RunAnalysisRequest,
-    analyst_db: AnalystDB,
+    analyst_db: AnalystDB | None = None,
     token_tracker: TokenUsageTracker | None = None,
     telemetry_json: dict[str, Any] | None = None,
+    analysis_context: RunCompleteAnalysisRequestContext | None = None,
 ) -> RunAnalysisResult:
     """Execute analysis workflow on datasets."""
     logger.debug("Entering run_analysis")
@@ -1567,6 +1598,7 @@ async def run_analysis(
             analyst_db=analyst_db,
             token_tracker=token_tracker,
             telemetry_json=telemetry_json,
+            analysis_context=analysis_context,
         )
     except MaxReflectionAttempts as e:
         return RunAnalysisResult(
@@ -1809,6 +1841,61 @@ class AnalysisGenerationError:
     original_error: BaseException | None = None
 
 
+@dataclass
+class RunCompleteAnalysisRequestContext:
+    chat_request: ChatRequest
+    request: Request | None
+    data_source: DataSourceType
+    dataset_metadata: list[DatasetMetadata]
+    analyst_db: AnalystDB
+    chat_id: str
+    user_message_id: str
+    enable_chart_generation: bool
+    enable_business_insights: bool
+    token_tracker: TokenUsageTracker
+
+    user_message: AnalystChatMessage | None = None
+    assistant_message_id: str | None = None
+    assistant_message: AnalystChatMessage | None = None
+    database: DatabaseOperator[Any] | None = None
+    recipe: BaseRecipe | None = None
+
+    message_update_task: asyncio.Task[Any] | None = None
+
+    def stage_message_update(
+        self, target: Literal["assistant", "user"] = "assistant"
+    ) -> None:
+        target_message_id = (
+            self.assistant_message_id if target == "assistant" else self.user_message_id
+        )
+        target_message = copy.copy(
+            self.assistant_message if target == "assistant" else self.user_message
+        )
+        if target_message:
+            target_message.step = copy.copy(target_message.step)
+
+        if not target_message or not target_message_id:
+            return
+
+        previous_task = self.message_update_task
+
+        async def update_task() -> None:
+            if previous_task:
+                await previous_task
+
+            await self.analyst_db.update_chat_message(
+                message_id=target_message_id,
+                message=target_message,
+            )
+
+        self.message_update_task = asyncio.create_task(update_task())
+
+    async def await_message_update(self) -> None:
+        if self.message_update_task:
+            await self.message_update_task
+            self.message_update_task = None
+
+
 async def execute_business_analysis_and_charts(
     analysis_result: RunAnalysisResult | RunDatabaseAnalysisResult,
     enhanced_message: str,
@@ -1870,8 +1957,22 @@ async def run_complete_analysis(
     telemetry_json: dict[str, Any] | None = None,
 ) -> AsyncGenerator[Component | AnalysisGenerationError, None]:
     datasets_names = [ds.name for ds in dataset_metadata]
+    token_tracker = TokenUsageTracker(strategy=TiktokenCountingStrategy())
+    analysis_context = RunCompleteAnalysisRequestContext(
+        chat_request=chat_request,
+        request=request,
+        data_source=data_source,
+        dataset_metadata=dataset_metadata,
+        analyst_db=analyst_db,
+        chat_id=chat_id,
+        user_message_id=message_id,
+        enable_chart_generation=enable_chart_generation,
+        enable_business_insights=enable_business_insights,
+        token_tracker=token_tracker,
+    )
 
     user_message = await analyst_db.get_chat_message(message_id=message_id)
+    analysis_context.user_message = user_message
     if user_message is None or user_message.role != "user":
         yield AnalysisGenerationError("Message not found")
 
@@ -1885,8 +1986,6 @@ async def run_complete_analysis(
         telemetry_json["enable_chart_generation"] = enable_chart_generation
         telemetry_json["enable_business_insights"] = enable_business_insights
     try:
-        token_tracker = TokenUsageTracker(strategy=TiktokenCountingStrategy())
-
         logger.info("Getting rephrased question...")
         enhanced_message = await rephrase_message(
             chat_request, token_tracker=token_tracker, telemetry_json=telemetry_json
@@ -1913,8 +2012,20 @@ async def run_complete_analysis(
         components=[EnhancedQuestionGeneration(enhanced_user_message=enhanced_message)],
         in_progress=True,
     )
+    should_test_connection = (
+        data_source == InternalDataSourceType.DATABASE
+        or data_source == InternalDataSourceType.REMOTE_REGISTRY
+        or isinstance(data_source, ExternalDataStoreNameDataSourceType)
+    )
+    assistant_message.step_value = (
+        "TESTING_CONNECTION" if should_test_connection else "GENERATING_QUERY"
+    )
+    analysis_context.assistant_message = assistant_message
 
-    await analyst_db.add_chat_message(chat_id=chat_id, message=assistant_message)
+    analysis_context.assistant_message_id = await analyst_db.add_chat_message(
+        chat_id=chat_id,
+        message=assistant_message,
+    )
 
     user_message.in_progress = False
     await analyst_db.update_chat_message(
@@ -2042,14 +2153,15 @@ async def run_complete_analysis(
                         dataset_names=datasets_names,
                         question=enhanced_message,
                     ),
-                    analyst_db,
-                    token_tracker,
+                    analysis_context=analysis_context,
+                    telemetry_json=telemetry_json,
                 )
             else:
                 raise ValueError(
                     "Cannot run analysis on a mix of local and remote datasets."
                 )
 
+        await analysis_context.await_message_update()
         log_memory()
         logger.info("Getting analysis result done")
 

--- a/utils/api.py
+++ b/utils/api.py
@@ -2154,6 +2154,7 @@ async def run_complete_analysis(
                         question=enhanced_message,
                     ),
                     analysis_context=analysis_context,
+                    token_tracker=token_tracker,
                     telemetry_json=telemetry_json,
                 )
             else:

--- a/utils/database_helpers.py
+++ b/utils/database_helpers.py
@@ -120,6 +120,14 @@ class DatabaseOperator(ABC, Generic[T]):
         """Return a query-friendly version of the dataset name (e.g. quoted table name if that's required)."""
         return dataset_name
 
+    def warmup_query(self) -> str | None:
+        return None
+
+    async def warmup(self) -> None:
+        query = self.warmup_query()
+        if query:
+            await self.execute_query(query)
+
 
 class NoDatabaseOperator(DatabaseOperator[NoDatabaseCredentialArgs]):
     def __init__(


### PR DESCRIPTION
## Summary
- Port a scoped subset of upstream v0.4.24 analysis execution updates into utils/api.py.
- Add RunCompleteAnalysisRequestContext with ordered staged message updates.
- Update local analysis execution to persist GENERATING_QUERY and RUNNING_QUERY steps while preserving pandas DataFrame execution.
- Add no-op DatabaseOperator warmup compatibility without replacing the legacy DB hierarchy.

## pandas compatibility
- Do not add polars to api.py execution modules or allowed modules.
- Added regression coverage that run_analysis receives and returns pandas-backed AnalystDataset data.

## Tests
- uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py
- uv run ruff check utils/api.py utils/database_helpers.py app_backend/tests/test_api_analysis_execution_v0424_compat.py
- uv run ruff format --check utils/api.py utils/database_helpers.py app_backend/tests/test_api_analysis_execution_v0424_compat.py