### PR TITLE
PR5: Port v0.4.24 API validation error handling

### DIFF
--- a/app_backend/tests/test_api_validation_errors_v0424_compat.py
+++ b/app_backend/tests/test_api_validation_errors_v0424_compat.py
@@ -1,0 +1,193 @@
+import asyncio
+import os
+from types import SimpleNamespace
+from typing import Any
+
+import pandas as pd
+from openai.types.chat.chat_completion_system_message_param import (
+    ChatCompletionSystemMessageParam,
+)
+from pydantic import BaseModel, ValidationError
+
+os.environ.setdefault("DATAROBOT_API_TOKEN", "test-token")
+os.environ.setdefault("DATAROBOT_ENDPOINT", "https://example.com")
+os.environ.setdefault("OTEL_SDK_DISABLED", "true")
+
+from utils import api
+from utils.schema import (
+    AnalystDataset,
+    DataDictionary,
+    GetBusinessAnalysisRequest,
+    RunAnalysisRequest,
+    RunChartsRequest,
+    RunDatabaseAnalysisRequest,
+)
+
+
+class _RequiredCode(BaseModel):
+    code: str
+
+
+def _validation_error() -> ValidationError:
+    try:
+        _RequiredCode.model_validate({})
+    except ValidationError as error:
+        return error
+    raise AssertionError("Expected pydantic validation to fail")
+
+
+def _exception_stderr(result: Any) -> str:
+    assert result.metadata is not None
+    assert result.metadata.exception is not None
+    assert result.metadata.exception.exception_history is not None
+    exception = result.metadata.exception.exception_history[0]
+    assert exception.stderr is not None
+    return exception.stderr
+
+
+def test_run_analysis_converts_llm_validation_error(monkeypatch) -> None:
+    asyncio.run(_assert_run_analysis_converts_llm_validation_error(monkeypatch))
+
+
+async def _assert_run_analysis_converts_llm_validation_error(monkeypatch) -> None:
+    async def fake_run_analysis(*args, **kwargs) -> api.RunAnalysisResult:
+        raise _validation_error()
+
+    monkeypatch.setattr(api, "_run_analysis", fake_run_analysis)
+
+    result = await api.run_analysis(
+        RunAnalysisRequest(dataset_names=["sales"], question="sum amount"),
+        analyst_db=object(),  # type: ignore[arg-type]
+    )
+
+    assert result.status == "error"
+    assert "Unable to complete the analysis" in _exception_stderr(result)
+
+
+def test_run_charts_converts_llm_validation_error(monkeypatch) -> None:
+    asyncio.run(_assert_run_charts_converts_llm_validation_error(monkeypatch))
+
+
+async def _assert_run_charts_converts_llm_validation_error(monkeypatch) -> None:
+    async def fake_run_charts(*args, **kwargs) -> api.RunChartsResult:
+        raise _validation_error()
+
+    monkeypatch.setattr(api, "_run_charts", fake_run_charts)
+
+    result = await api.run_charts(
+        RunChartsRequest(
+            dataset=AnalystDataset(data=pd.DataFrame({"amount": [100, 200]})),
+            question="chart amount",
+        )
+    )
+
+    assert result.status == "error"
+    assert "Unable to generate charts" in _exception_stderr(result)
+
+
+def test_get_business_analysis_converts_llm_validation_error(monkeypatch) -> None:
+    asyncio.run(
+        _assert_get_business_analysis_converts_llm_validation_error(monkeypatch)
+    )
+
+
+async def _assert_get_business_analysis_converts_llm_validation_error(
+    monkeypatch,
+) -> None:
+    class FakeCompletions:
+        async def create_with_completion(self, **kwargs) -> tuple[Any, Any]:
+            raise _validation_error()
+
+    class FakeLLMClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+        async def __aenter__(self) -> "FakeLLMClient":
+            return self
+
+        async def __aexit__(self, *args) -> None:
+            return None
+
+    monkeypatch.setattr(api, "AsyncLLMClient", FakeLLMClient)
+
+    dataset = AnalystDataset(data=pd.DataFrame({"amount": [100, 200]}))
+    result = await api.get_business_analysis(
+        GetBusinessAnalysisRequest(
+            dataset=dataset,
+            dictionary=DataDictionary.from_analyst_df(dataset.to_df()),
+            question="summarize amount",
+        )
+    )
+
+    assert result.status == "error"
+    assert "Unable to generate business insights" in _exception_stderr(result)
+
+
+def test_generate_database_analysis_code_converts_llm_validation_error(
+    monkeypatch,
+) -> None:
+    asyncio.run(
+        _assert_generate_database_analysis_code_converts_llm_validation_error(
+            monkeypatch
+        )
+    )
+
+
+async def _assert_generate_database_analysis_code_converts_llm_validation_error(
+    monkeypatch,
+) -> None:
+    class FakeAnalystDB:
+        async def get_data_dictionary(self, name: str) -> DataDictionary:
+            return DataDictionary.from_analyst_df(
+                pd.DataFrame({"amount": [100]}),
+                name=name,
+            )
+
+        async def get_dataset_metadata(self, name: str) -> SimpleNamespace:
+            return SimpleNamespace(original_column_types={"amount": "INTEGER"})
+
+        async def get_dataset(self, name: str) -> AnalystDataset:
+            return AnalystDataset(
+                name=name,
+                data=pd.DataFrame({"amount": [100]}),
+            )
+
+    class FakeDatabase:
+        def query_friendly_name(self, dataset_name: str) -> str:
+            return dataset_name
+
+        def get_system_prompt(self) -> ChatCompletionSystemMessageParam:
+            return ChatCompletionSystemMessageParam(
+                role="system",
+                content="Generate SQL",
+            )
+
+    class FakeCompletions:
+        async def create_with_completion(self, **kwargs) -> tuple[Any, Any]:
+            raise _validation_error()
+
+    class FakeLLMClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+        async def __aenter__(self) -> "FakeLLMClient":
+            return self
+
+        async def __aexit__(self, *args) -> None:
+            return None
+
+    monkeypatch.setattr(api, "AsyncLLMClient", FakeLLMClient)
+
+    try:
+        await api._generate_database_analysis_code(
+            FakeDatabase(),  # type: ignore[arg-type]
+            RunDatabaseAnalysisRequest(
+                dataset_names=["PUBLIC.sales"],
+                question="sum amount",
+            ),
+            FakeAnalystDB(),  # type: ignore[arg-type]
+        )
+    except ValueError as error:
+        assert "Unable to analyze your data" in str(error)
+    else:
+        raise AssertionError("Expected database analysis generation to fail")

--- a/customize_docs/upstream_sync_plan.md
+++ b/customize_docs/upstream_sync_plan.md
@@ -51,7 +51,8 @@
 3. PR3では `utils/rest_api.py` のCSV decode/validationとdatabase endpointのbackground化を移植する。pandas前提は維持し、CSV loaderは `pd.DataFrame` を返す。
 4. PR4では `utils/api.py` の分析実行まわりから、`RunCompleteAnalysisRequestContext` と分析step更新 (`GENERATING_QUERY` / `RUNNING_QUERY`) を移植する。pandas前提は維持し、upstreamの `polars` allowed module追加や `pd.DataFrame` 置換は取り込まない。
 5. PR5では `utils/api.py` のLLM応答validation/error handling差分を小さく移植する。チャート生成、ビジネス分析、database SQL生成で `ValidationError` をユーザー向けの `AnalysisError` に変換する。
-6. Streamlit (`frontend/*`) は破棄方針のため、upstream同期では衝突解消せず別途削除・整理する。
+6. `utils/api.py` と `utils/rest_api.py` の残り差分は upstream 版を全面採用せず、既存カスタムAPIのcharacterization testを通しながら必要差分だけ移植する。
+7. Streamlit (`frontend/*`) は破棄方針のため、upstream同期では衝突解消せず別途削除・整理する。
 
 ## PR2 CI対応メモ
 
@@ -74,3 +75,10 @@
 - `run_complete_analysis()` はローカル分析経路でcontextを渡す。既存のpandas DataFrame入力、`execute_python` の allowed modules、`AnalystDataset.to_df()` は維持する。
 - legacy `utils.database_helpers.DatabaseOperator` に no-op `warmup_query()` / `warmup()` を追加し、upstreamの接続テスト呼び出しに備える。DB実装階層や `utils.data_connections` への全面差し替えはしない。
 - 追加テスト: `app_backend/tests/test_api_analysis_execution_v0424_compat.py`。staged updateの順序、`run_analysis` のstep更新、pandas DataFrame維持、no-op warmupを検証する。
+
+## PR5 実装メモ
+
+- 2026-06-07: `utils/api.py` の LLM response parsing failure を個別に扱う。`run_analysis()`、`run_charts()`、`get_business_analysis()`、`_generate_database_analysis_code()` で `ValidationError` を raw のまま返さず、ユーザー向けの `AnalysisError` / `ValueError` へ変換する。
+- `get_business_analysis()` は `ValueError` とその他例外も分離し、ユーザーに返すmetadataでは `exception=AnalysisError.from_value_error(...)` を使う。既存の成功レスポンスとpandas DataFrame入力は変更しない。
+- `_generate_database_analysis_code()` は LLM応答のvalidation失敗を database SQL生成用の説明メッセージに変換する。SQL sample生成は既存のpandas `.to_df()` 経路を維持する。
+- 追加テスト: `app_backend/tests/test_api_validation_errors_v0424_compat.py`。analysis/charts/business/database SQL生成の4経路で raw `ValidationError` が外に出ず、ユーザー向けメッセージに変換されることを検証する。

--- a/utils/api.py
+++ b/utils/api.py
@@ -1344,9 +1344,20 @@ async def run_charts(
             request, token_tracker=token_tracker, telemetry_json=telemetry_json
         )
         return chart_result
-    except ValidationError:
+    except ValidationError as e:
+        logger.error(f"Failed to parse LLM response for charts: {e}")
+        user_friendly_error = ValueError(
+            "Unable to generate charts for this analysis. "
+            "The data structure may not be suitable for visualization. "
+            "The analysis results are still available."
+        )
         return RunChartsResult(
-            status="error", metadata=RunAnalysisResultMetadata(duration=0, attempts=1)
+            status="error",
+            metadata=RunAnalysisResultMetadata(
+                duration=0,
+                attempts=1,
+                exception=AnalysisError.from_value_error(user_friendly_error),
+            ),
         )
     except MaxReflectionAttempts as e:
         return RunChartsResult(
@@ -1450,6 +1461,33 @@ async def get_business_analysis(
             metadata=metadata,
         )
 
+    except ValidationError as e:
+        logger.error(f"Failed to parse LLM response for business analysis: {e}")
+        user_friendly_error = ValueError(
+            "Unable to generate business insights for this analysis. "
+            "The analysis results are still available. "
+            "Try simplifying your question or checking your data."
+        )
+        return GetBusinessAnalysisResult(
+            status="error",
+            metadata=GetBusinessAnalysisMetadata(
+                exception=AnalysisError.from_value_error(user_friendly_error)
+            ),
+            additional_insights="",
+            follow_up_questions=[],
+            bottom_line="",
+        )
+    except ValueError as e:
+        logger.error(f"ValueError during business analysis generation: {e}")
+        return GetBusinessAnalysisResult(
+            status="error",
+            metadata=GetBusinessAnalysisMetadata(
+                exception=AnalysisError.from_value_error(e)
+            ),
+            additional_insights="",
+            follow_up_questions=[],
+            bottom_line="",
+        )
     except Exception as e:
         msg = type(e).__name__ + f": {str(e)}"
         logger.error(f"Error in get_business_analysis: {msg}")
@@ -1609,6 +1647,21 @@ async def run_analysis(
                 exception=AnalysisError.from_max_reflection_exception(e),
             ),
         )
+    except ValidationError as e:
+        logger.error(f"Failed to parse LLM response for analysis: {e}")
+        user_friendly_error = ValueError(
+            "Unable to complete the analysis. "
+            "This could be due to data quality issues, complex dataset structure, or the question being too complex. "
+            "Try simplifying your question or verifying your data quality."
+        )
+        return RunAnalysisResult(
+            status="error",
+            metadata=RunAnalysisResultMetadata(
+                duration=0,
+                attempts=1,
+                exception=AnalysisError.from_value_error(user_friendly_error),
+            ),
+        )
     except ValueError as e:
         return RunAnalysisResult(
             status="error",
@@ -1718,15 +1771,23 @@ async def _generate_database_analysis_code(
         with telemetry.time(
             f"{_generate_database_analysis_code.__module__}.{_generate_database_analysis_code.__qualname__}.llm_call"
         ):
-            (
-                completion,
-                completion_org,
-            ) = await client.chat.completions.create_with_completion(
-                response_model=DatabaseAnalysisCodeGeneration,
-                model=ALTERNATIVE_LLM_BIG,
-                temperature=0.1,
-                messages=messages,
-            )
+            try:
+                (
+                    completion,
+                    completion_org,
+                ) = await client.chat.completions.create_with_completion(
+                    response_model=DatabaseAnalysisCodeGeneration,
+                    model=ALTERNATIVE_LLM_BIG,
+                    temperature=0.1,
+                    messages=messages,
+                )
+            except ValidationError as e:
+                logger.error(f"LLM returned invalid database analysis response: {e}")
+                raise ValueError(
+                    "Unable to analyze your data. "
+                    "This could be due to data quality issues, complex dataset structure, or the question being too complex. "
+                    "Try simplifying your question or checking your data."
+                ) from e
     association_id = completion_org.datarobot_moderations["association_id"]
     logger.info(f"Association ID: {association_id}")
 


### PR DESCRIPTION
## Summary
- Stacked on PR #68.
- Port a scoped subset of upstream v0.4.24 API validation error handling.
- Convert LLM response ValidationError failures into user-facing AnalysisError/ValueError messages for analysis, charts, business insights, and database SQL generation.
- Keep pandas-backed AnalystDataset and existing API success paths unchanged.

## pandas compatibility
- No polars conversion or allowed-module expansion is included.
- Database SQL prompt sample generation continues to use the existing pandas .to_df() path.

## Tests
- uv run pytest app_backend/tests/test_api_validation_errors_v0424_compat.py
- uv run pytest app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_api_validation_errors_v0424_compat.py app_backend/tests/test_rest_api_v0424_compat.py app_backend/tests/test_analyst_db_upstream_compat.py app_backend/tests/test_upstream_compat_imports.py
- uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py
- uv run ruff check utils/api.py utils/database_helpers.py app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_api_validation_errors_v0424_compat.py
- uv run ruff format --check utils/api.py utils/database_helpers.py app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_api_validation_errors_v0424_compat.py