### PR TITLE
PR6: Propagate telemetry to database analysis paths

### DIFF
--- a/app_backend/tests/test_api_analysis_execution_v0424_compat.py
+++ b/app_backend/tests/test_api_analysis_execution_v0424_compat.py
@@ -1,16 +1,24 @@
+import ast
 import asyncio
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
+import pytest
 
 os.environ.setdefault("DATAROBOT_API_TOKEN", "test-token")
 os.environ.setdefault("DATAROBOT_ENDPOINT", "https://example.com")
 os.environ.setdefault("OTEL_SDK_DISABLED", "true")
 
 from utils import api
-from utils.analyst_db import DatasetMetadata, DatasetType, InternalDataSourceType
+from utils.analyst_db import (
+    DatasetMetadata,
+    DatasetType,
+    ExternalDataStoreNameDataSourceType,
+    InternalDataSourceType,
+)
 from utils.credentials import NoDatabaseCredentials
 from utils.database_helpers import NoDatabaseOperator
 from utils.schema import (
@@ -20,6 +28,8 @@ from utils.schema import (
     RunAnalysisRequest,
     RunAnalysisResult,
     RunAnalysisResultMetadata,
+    RunDatabaseAnalysisResult,
+    RunDatabaseAnalysisResultMetadata,
 )
 from utils.token_tracking import TiktokenCountingStrategy, TokenUsageTracker
 
@@ -36,6 +46,17 @@ def _dataset_metadata(name: str) -> DatasetMetadata:
         row_count=2,
         data_source=InternalDataSourceType.FILE,
     )
+
+
+def _dataset_metadata_for_source(
+    name: str,
+    data_source: InternalDataSourceType | ExternalDataStoreNameDataSourceType,
+    external_id: str | None = None,
+) -> DatasetMetadata:
+    metadata = _dataset_metadata(name)
+    metadata.data_source = data_source
+    metadata.external_id = external_id
+    return metadata
 
 
 def _analysis_context(analyst_db: Any) -> api.RunCompleteAnalysisRequestContext:
@@ -273,3 +294,271 @@ async def _assert_run_complete_analysis_passes_tracker_and_telemetry_to_run_anal
         run_analysis_kwargs["token_tracker"]
         is run_analysis_kwargs["analysis_context"].token_tracker
     )
+
+
+@pytest.mark.parametrize(
+    "case_name",
+    ["database", "external_data_store", "remote_registry"],
+)
+def test_run_complete_analysis_passes_telemetry_to_database_analysis_paths(
+    monkeypatch,
+    case_name: str,
+) -> None:
+    asyncio.run(
+        _assert_run_complete_analysis_passes_telemetry_to_database_analysis_paths(
+            monkeypatch,
+            case_name,
+        )
+    )
+
+
+async def _assert_run_complete_analysis_passes_telemetry_to_database_analysis_paths(
+    monkeypatch,
+    case_name: str,
+) -> None:
+    class FakeAnalystDB:
+        def __init__(self) -> None:
+            self.user_message = AnalystChatMessage(
+                id="user-1",
+                role="user",
+                content="sum amount",
+                components=[],
+                in_progress=True,
+            )
+
+        async def get_chat_message(self, message_id: str) -> AnalystChatMessage | None:
+            if message_id == "user-1":
+                return self.user_message
+            return None
+
+        async def add_chat_message(
+            self, chat_id: str, message: AnalystChatMessage
+        ) -> str:
+            message.id = "assistant-1"
+            return message.id
+
+        async def update_chat_message(
+            self, message_id: str, message: AnalystChatMessage
+        ) -> None:
+            return None
+
+    class FakeRecipe:
+        async def refresh(self) -> bool:
+            return False
+
+        def as_database_operator(self) -> object:
+            return object()
+
+    async def fake_rephrase_message(*args, **kwargs) -> str:
+        return "enhanced question"
+
+    async def fake_extract_and_store_datasets(
+        analyst_db: FakeAnalystDB,
+        assistant_message: AnalystChatMessage,
+    ) -> AnalystChatMessage:
+        return assistant_message
+
+    run_database_analysis_kwargs: dict[str, Any] = {}
+
+    async def fake_run_database_analysis(*args, **kwargs) -> RunDatabaseAnalysisResult:
+        run_database_analysis_kwargs.update(kwargs)
+        return RunDatabaseAnalysisResult(
+            status="success",
+            dataset=AnalystDataset(
+                name="database_result",
+                data=pd.DataFrame({"total_amount": [300]}),
+            ),
+            metadata=RunDatabaseAnalysisResultMetadata(
+                duration=0,
+                attempts=1,
+                datasets_analyzed=1,
+            ),
+        )
+
+    monkeypatch.setattr(api, "rephrase_message", fake_rephrase_message)
+    monkeypatch.setattr(api, "run_database_analysis", fake_run_database_analysis)
+    monkeypatch.setattr(
+        api,
+        "extract_and_store_datasets",
+        fake_extract_and_store_datasets,
+    )
+
+    if case_name == "database":
+        data_source = InternalDataSourceType.DATABASE
+        dataset_metadata = [
+            _dataset_metadata_for_source("sales", InternalDataSourceType.DATABASE)
+        ]
+    elif case_name == "external_data_store":
+        data_source = ExternalDataStoreNameDataSourceType.from_name("warehouse")
+        dataset_metadata = [_dataset_metadata_for_source("sales", data_source)]
+
+        async def fake_get_data_store_id(name: str) -> str:
+            assert name == "warehouse"
+            return "data-store-id"
+
+        async def fake_load_or_create(*args, **kwargs) -> FakeRecipe:
+            return FakeRecipe()
+
+        monkeypatch.setattr(
+            api.DataSourceRecipe,
+            "get_id_for_data_store_canonical_name",
+            staticmethod(fake_get_data_store_id),
+        )
+        monkeypatch.setattr(
+            api.DataSourceRecipe,
+            "load_or_create",
+            staticmethod(fake_load_or_create),
+        )
+    elif case_name == "remote_registry":
+        data_source = InternalDataSourceType.REMOTE_REGISTRY
+        dataset_metadata = [
+            _dataset_metadata_for_source(
+                "sales",
+                InternalDataSourceType.REMOTE_REGISTRY,
+                external_id="remote-dataset-id",
+            )
+        ]
+
+        monkeypatch.setattr(
+            api.DatasetSparkRecipe,
+            "should_use_spark_recipe",
+            staticmethod(lambda: True),
+        )
+
+        async def fake_load_or_create_spark_recipe(*args, **kwargs) -> FakeRecipe:
+            return FakeRecipe()
+
+        monkeypatch.setattr(
+            api,
+            "load_or_create_spark_recipe",
+            fake_load_or_create_spark_recipe,
+        )
+    else:
+        raise AssertionError(f"Unexpected case: {case_name}")
+
+    telemetry_json = {"request_id": f"telemetry-{case_name}"}
+
+    results = [
+        component
+        async for component in api.run_complete_analysis(
+            chat_request=ChatRequest(
+                messages=[{"role": "user", "content": "sum amount"}]
+            ),
+            data_source=data_source,
+            dataset_metadata=dataset_metadata,
+            analyst_db=FakeAnalystDB(),  # type: ignore[arg-type]
+            chat_id="chat-1",
+            message_id="user-1",
+            request=None,
+            enable_chart_generation=False,
+            enable_business_insights=False,
+            telemetry_json=telemetry_json,
+        )
+    ]
+
+    assert results[0] == "enhanced question"
+    assert isinstance(results[1], RunDatabaseAnalysisResult)
+    assert run_database_analysis_kwargs["telemetry_json"] is telemetry_json
+    assert run_database_analysis_kwargs["token_tracker"] is not None
+
+
+def test_all_database_analysis_calls_pass_telemetry_json() -> None:
+    assert api.__file__ is not None
+    api_tree = ast.parse(Path(api.__file__).read_text())
+    database_analysis_functions = {
+        "run_database_analysis",
+        "_run_database_analysis",
+        "_generate_database_analysis_code",
+    }
+    missing_telemetry_lines: dict[str, list[int]] = {
+        function_name: [] for function_name in database_analysis_functions
+    }
+
+    for node in ast.walk(api_tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id not in database_analysis_functions:
+            continue
+        if not any(keyword.arg == "telemetry_json" for keyword in node.keywords):
+            missing_telemetry_lines[node.func.id].append(node.lineno)
+
+    assert missing_telemetry_lines == {
+        function_name: [] for function_name in database_analysis_functions
+    }
+
+
+def test_run_database_analysis_passes_generator_context_without_argument_shift(
+    monkeypatch,
+) -> None:
+    asyncio.run(
+        _assert_run_database_analysis_passes_generator_context_without_argument_shift(
+            monkeypatch
+        )
+    )
+
+
+async def _assert_run_database_analysis_passes_generator_context_without_argument_shift(
+    monkeypatch,
+) -> None:
+    class FakeDatabase:
+        async def execute_query(self, query: str) -> list[dict[str, int]]:
+            assert query == "select 300 as total_amount"
+            return [{"total_amount": 300}]
+
+    async def fake_generate_database_analysis_code(
+        database: FakeDatabase,
+        request: api.RunDatabaseAnalysisRequest,
+        analyst_db: object,
+        validation_error: object | None = None,
+        token_tracker: TokenUsageTracker | None = None,
+        telemetry_json: dict[str, Any] | None = None,
+    ) -> str:
+        call_context.update(
+            {
+                "database": database,
+                "request": request,
+                "analyst_db": analyst_db,
+                "validation_error": validation_error,
+                "token_tracker": token_tracker,
+                "telemetry_json": telemetry_json,
+            }
+        )
+        return "select 300 as total_amount"
+
+    call_context: dict[str, object | None] = {}
+    fake_database = FakeDatabase()
+    fake_analyst_db = object()
+    token_tracker = TokenUsageTracker(strategy=TiktokenCountingStrategy())
+    telemetry_json = {"request_id": "database-telemetry"}
+    request = api.RunDatabaseAnalysisRequest(
+        dataset_names=["PUBLIC.sales"],
+        question="sum amount",
+    )
+
+    monkeypatch.setattr(
+        api,
+        "_generate_database_analysis_code",
+        fake_generate_database_analysis_code,
+    )
+
+    result = await api.run_database_analysis(
+        request=request,
+        analyst_db=fake_analyst_db,  # type: ignore[arg-type]
+        database_override=fake_database,  # type: ignore[arg-type]
+        token_tracker=token_tracker,
+        telemetry_json=telemetry_json,
+    )
+
+    assert result.status == "success"
+    assert result.dataset is not None
+    assert result.dataset.to_df().to_dict("records") == [{"total_amount": 300}]
+    assert call_context == {
+        "database": fake_database,
+        "request": request,
+        "analyst_db": fake_analyst_db,
+        "validation_error": None,
+        "token_tracker": token_tracker,
+        "telemetry_json": telemetry_json,
+    }

--- a/customize_docs/upstream_sync_plan.md
+++ b/customize_docs/upstream_sync_plan.md
@@ -51,8 +51,9 @@
 3. PR3では `utils/rest_api.py` のCSV decode/validationとdatabase endpointのbackground化を移植する。pandas前提は維持し、CSV loaderは `pd.DataFrame` を返す。
 4. PR4では `utils/api.py` の分析実行まわりから、`RunCompleteAnalysisRequestContext` と分析step更新 (`GENERATING_QUERY` / `RUNNING_QUERY`) を移植する。pandas前提は維持し、upstreamの `polars` allowed module追加や `pd.DataFrame` 置換は取り込まない。
 5. PR5では `utils/api.py` のLLM応答validation/error handling差分を小さく移植する。チャート生成、ビジネス分析、database SQL生成で `ValidationError` をユーザー向けの `AnalysisError` に変換する。
-6. `utils/api.py` と `utils/rest_api.py` の残り差分は upstream 版を全面採用せず、既存カスタムAPIのcharacterization testを通しながら必要差分だけ移植する。
-7. Streamlit (`frontend/*`) は破棄方針のため、upstream同期では衝突解消せず別途削除・整理する。
+6. PR6では `run_complete_analysis()` のdatabase分析経路で `telemetry_json` を `run_database_analysis()` へ渡す。External Data Store の `data_source` telemetryは `.value` ではなく `.name` を使う。
+7. `utils/api.py` と `utils/rest_api.py` の残り差分は upstream 版を全面採用せず、既存カスタムAPIのcharacterization testを通しながら必要差分だけ移植する。
+8. Streamlit (`frontend/*`) は破棄方針のため、upstream同期では衝突解消せず別途削除・整理する。
 
 ## PR2 CI対応メモ
 
@@ -82,3 +83,10 @@
 - `get_business_analysis()` は `ValueError` とその他例外も分離し、ユーザーに返すmetadataでは `exception=AnalysisError.from_value_error(...)` を使う。既存の成功レスポンスとpandas DataFrame入力は変更しない。
 - `_generate_database_analysis_code()` は LLM応答のvalidation失敗を database SQL生成用の説明メッセージに変換する。SQL sample生成は既存のpandas `.to_df()` 経路を維持する。
 - 追加テスト: `app_backend/tests/test_api_validation_errors_v0424_compat.py`。analysis/charts/business/database SQL生成の4経路で raw `ValidationError` が外に出ず、ユーザー向けメッセージに変換されることを検証する。
+
+## PR6 実装メモ
+
+- 2026-06-07: `run_complete_analysis()` のdatabase分析3経路 (`DATABASE`, External Data Store, Remote Registry) から `run_database_analysis()` へ `telemetry_json` が渡ることを回帰テストで固定する。
+- Direct database経路は既に `telemetry_json` を渡していたため、External Data Store と Remote Registry の `database_override` 経路に追加する。
+- External Data Store は `ExternalDataStoreNameDataSourceType` で `.value` を持たないため、telemetryの `data_source` には `.name` を使う。Internal sourceは従来どおり `.value` を使う。
+- 2026-06-08: `run_database_analysis()` の内側も確認し、`_run_database_analysis()` から `_generate_database_analysis_code()` への呼び出しで `database` が余分に1つ渡されていた問題を修正する。`run_database_analysis` / `_run_database_analysis` / `_generate_database_analysis_code` の全呼び出しに `telemetry_json` keyword があることをASTテストで固定する。

--- a/utils/api.py
+++ b/utils/api.py
@@ -1826,7 +1826,6 @@ async def _run_database_analysis(
 
     sql_code = await _generate_database_analysis_code(
         database,
-        database,
         request,
         analyst_db,
         next(iter(exception_history[::-1]), None),
@@ -2042,7 +2041,11 @@ async def run_complete_analysis(
     if telemetry_json is not None:
         telemetry_json["chat_id"] = chat_id
         telemetry_json["chat_seq"] = len(chat_request.messages)
-        telemetry_json["data_source"] = data_source.value
+        telemetry_json["data_source"] = (
+            data_source.value
+            if isinstance(data_source, InternalDataSourceType)
+            else data_source.name
+        )
         telemetry_json["datasets_names"] = datasets_names
         telemetry_json["enable_chart_generation"] = enable_chart_generation
         telemetry_json["enable_business_insights"] = enable_business_insights
@@ -2167,6 +2170,7 @@ async def run_complete_analysis(
                 analyst_db,
                 database_override=recipe.as_database_operator(),
                 token_tracker=token_tracker,
+                telemetry_json=telemetry_json,
             )
 
         else:
@@ -2206,6 +2210,7 @@ async def run_complete_analysis(
                     analyst_db,
                     database_override=recipe.as_database_operator(),
                     token_tracker=token_tracker,
+                    telemetry_json=telemetry_json,
                 )
             elif all(m.external_id is None for m in dataset_metadata):
                 logging.info("Running local analysis")


### PR DESCRIPTION
## Summary
- Stacked on PR #69.
- Pass telemetry_json from run_complete_analysis into all run_database_analysis paths.
- Preserve existing direct database behavior and add missing propagation for External Data Store and Remote Registry database_override paths.
- Fix External Data Store telemetry data_source serialization by using data_source.name instead of .value.

## pandas compatibility
- No pandas-to-polars changes.
- Existing pandas-backed AnalystDataset paths remain unchanged.

## Tests
- uv run pytest app_backend/tests/test_api_analysis_execution_v0424_compat.py::test_run_complete_analysis_passes_telemetry_to_database_analysis_paths
- uv run pytest app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_api_validation_errors_v0424_compat.py app_backend/tests/test_rest_api_v0424_compat.py app_backend/tests/test_analyst_db_upstream_compat.py app_backend/tests/test_upstream_compat_imports.py
- uv run pytest app_backend/tests customize_docs/test_question_refiner.py customize_docs/test_report_questions_generator.py customize_docs/test_word_generation_llm.py
- uv run ruff check utils/api.py utils/database_helpers.py app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_api_validation_errors_v0424_compat.py
- uv run ruff format --check utils/api.py utils/database_helpers.py app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_api_validation_errors_v0424_compat.py