### PR TITLE
PR3: Add core FastAPI app factory boundary

### DIFF
--- a/app_backend/app/main.py
+++ b/app_backend/app/main.py
@@ -17,11 +17,11 @@ import logging
 import os
 from typing import Awaitable, Callable
 
+from core.data_analyst_telemetry import telemetry
+from core.rest_api import create_app
 from fastapi import APIRouter, Request
 from fastapi.responses import FileResponse, Response
 from fastapi.staticfiles import StaticFiles
-from utils.data_analyst_telemetry import telemetry
-from utils.rest_api import app
 
 # Configure logging to filter out the health check logs
 logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
@@ -40,6 +40,7 @@ SERVE_STATIC_FRONTEND = os.getenv("SERVE_STATIC_FRONTEND", "True").casefold() ==
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 STATIC_DIR = os.path.join(BASE_DIR, "static")
 base_router = APIRouter()
+app = create_app()
 
 
 def is_static_frontend_available(

--- a/app_backend/tests/test_v1151_fastapi_app_factory.py
+++ b/app_backend/tests/test_v1151_fastapi_app_factory.py
@@ -1,0 +1,57 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def _set_required_import_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "test-token")
+    monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://example.com")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+
+
+def test_core_rest_api_exposes_app_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_import_env(monkeypatch)
+
+    from core import rest_api
+
+    created_app = rest_api.create_app()
+
+    assert created_app is rest_api.app
+    assert any(
+        getattr(route, "path", "") == "/api/v1/config/feature-flags"
+        for route in created_app.routes
+    )
+
+
+def test_backend_main_starts_from_core_app_factory() -> None:
+    source_path = Path("app_backend/app/main.py")
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    imported_from_core = False
+    imported_from_legacy_utils = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        imported_names = {alias.name for alias in node.names}
+        if node.module == "core.rest_api" and "create_app" in imported_names:
+            imported_from_core = True
+        if node.module == "utils.rest_api":
+            imported_from_legacy_utils = True
+
+    assert imported_from_core
+    assert not imported_from_legacy_utils
+
+
+def test_backend_main_app_uses_core_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_import_env(monkeypatch)
+
+    from core.rest_api import create_app
+
+    from app import main
+
+    assert main.app is create_app()

--- a/core/src/core/rest_api.py
+++ b/core/src/core/rest_api.py
@@ -374,6 +374,11 @@ def custom_openapi() -> dict[str, Any]:
 app.openapi = custom_openapi  # type: ignore[method-assign]
 
 
+def create_app() -> FastAPI:
+    """Return the configured FastAPI application singleton."""
+    return app
+
+
 class SessionState(object):
     _state: dict[str, Any]
 

--- a/customize_docs/v11_5_1_integration_plan.md
+++ b/customize_docs/v11_5_1_integration_plan.md
@@ -255,6 +255,12 @@ PR2 の core package mechanical migration で、top-level 依存も切り替え�
 - `uv run pytest app_backend/tests/test_main.py app_backend/tests/test_v1150_compat.py app_backend/tests/test_rest_api_v0424_compat.py -q`
 - `uv run pytest app_backend/tests customize_docs -q`
 
+実装メモ:
+
+- 2026-06-12: `core.rest_api.create_app()` を追加し、既存の configured singleton `app` を返す app factory 境界を導入した。
+- `app_backend/app/main.py` は `utils.rest_api.app` の直接 import から `core.rest_api.create_app()` 呼び出しへ切り替えた。
+- このPRでは router 分割や deps/middleware の本格移植は行わない。customize routes、static frontend fallback、既存 session middleware を保ったまま、後続PRで `app_backend/app/__init__.py` に upstream の thin app 構成を取り込める入口だけ固定する。
+
 ### PR4: LLM configuration / LiteLLM integration
 
 目的: upstream `v11.5.1` の柔軟な LLM 設定を、既存 customize LLM と token tracking を壊さず取り込む。


### PR DESCRIPTION
## Summary
- Add `core.rest_api.create_app()` as the FastAPI app factory boundary while preserving the existing configured singleton app.
- Switch `app_backend/app/main.py` from `utils.rest_api.app` to `core.rest_api.create_app()`.
- Add regression tests for the new factory boundary and document the PR3 implementation note.

## Scope
This PR does not split routers or move middleware/deps yet. It only establishes the app creation boundary needed for the next staged FastAPI integration PR.

## Tests
- `PYTHONPATH=app_backend:. uv run pytest app_backend/tests/test_v1151_fastapi_app_factory.py -q`
- `PYTHONPATH=app_backend:. uv run pytest app_backend/tests/test_main.py app_backend/tests/test_v1150_compat.py app_backend/tests/test_rest_api_v0424_compat.py app_backend/tests/test_upstream_compat_imports.py app_backend/tests/test_v1151_fastapi_app_factory.py -q`
- `PYTHONPATH=app_backend:. uv run pytest app_backend/tests customize_docs -q`
- `uvx ruff check .`
- `uvx ruff format --check .`