### PR TITLE
Complete v11.5.1 FastAPI integration

### DIFF
--- a/app_backend/app/__init__.py
+++ b/app_backend/app/__init__.py
@@ -15,13 +15,22 @@
 import json
 import logging
 import os
-from typing import Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, Awaitable, Callable
 
-from core.data_analyst_telemetry import telemetry
 from core.rest_api import create_app as create_core_app
 from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import FileResponse, Response
 from fastapi.staticfiles import StaticFiles
+
+from app.config import Config
+from app.deps import Deps, create_deps
+from app.telemetry import configure_uvicorn_logging, init_logging
+
+try:
+    from datarobot_asgi_middleware import DataRobotASGIMiddleware
+except ImportError:
+    DataRobotASGIMiddleware = None  # type: ignore[assignment, misc]
 
 # Configure logging to filter out the health check logs
 logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
@@ -41,6 +50,11 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 STATIC_DIR = os.path.join(BASE_DIR, "static")
 base_router = APIRouter()
 _configured_app: FastAPI | None = None
+
+
+@base_router.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "healthy"}
 
 
 def is_static_frontend_available(
@@ -126,13 +140,44 @@ def create_static_path_middleware() -> Callable[
     return static_path_normalize
 
 
-def create_app() -> FastAPI:
+def _add_datarobot_asgi_middleware(app: FastAPI) -> None:
+    if DataRobotASGIMiddleware is None:
+        logging.getLogger(__name__).warning(
+            "datarobot-asgi-middleware is not installed; skipping DataRobot ASGI middleware."
+        )
+        return
+
+    app.add_middleware(DataRobotASGIMiddleware, health_endpoint="/health")
+
+
+def create_app(
+    title: str = "Data Analyst API",
+    config: Config | None = None,
+    deps: Deps | None = None,
+) -> FastAPI:
     global _configured_app
 
-    if _configured_app is not None:
+    cacheable = title == "Data Analyst API" and config is None and deps is None
+    if cacheable and _configured_app is not None:
         return _configured_app
 
-    app = create_core_app()
+    if config is None:
+        config = Config()
+
+    init_logging(level=config.log_level, format_type=config.log_format)
+    configure_uvicorn_logging(
+        log_format=config.log_format,
+        log_level=config.log_level.value,
+    )
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+        async with create_deps(config, deps) as dependencies:
+            app.state.deps = dependencies
+            yield
+
+    app = create_core_app(lifespan=lifespan, title=title)
+    _add_datarobot_asgi_middleware(app)
     app.include_router(base_router)
 
     if STATIC_FRONTEND_AVAILABLE:
@@ -141,12 +186,6 @@ def create_app() -> FastAPI:
         # Important to be last so that we fall back to the static files if the route is not found
         app.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")
 
-    # Initialize telemetry on application startup
-    telemetry.log_application_start()
-
-    # Setup auto-instrumentation for FastAPI
-    # This will automatically trace all incoming HTTP requests
-    telemetry.instrument_fastapi_app(app)
-
-    _configured_app = app
+    if cacheable:
+        _configured_app = app
     return app

--- a/app_backend/app/config.py
+++ b/app_backend/app/config.py
@@ -1,0 +1,22 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+
+from app.telemetry import FormatType, LogLevel
+
+
+class Config(DataRobotAppFrameworkBaseSettings):
+    log_level: LogLevel = LogLevel.INFO
+    log_format: FormatType = "json"

--- a/app_backend/app/deps.py
+++ b/app_backend/app/deps.py
@@ -1,0 +1,39 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import AsyncGenerator
+
+from app.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Deps:
+    config: Config
+
+
+@asynccontextmanager
+async def create_deps(
+    config: Config, deps: Deps | None = None
+) -> AsyncGenerator[Deps, None]:
+    """Create app-scoped dependencies for startup and shutdown."""
+    if deps:
+        yield deps
+        return
+
+    yield Deps(config=config)

--- a/app_backend/app/telemetry/__init__.py
+++ b/app_backend/app/telemetry/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .logging import FormatType, JsonFormatter, LogLevel, TextFormatter, init_logging
+from .uvicorn_filter import configure_uvicorn_logging
+
+__all__ = [
+    "FormatType",
+    "JsonFormatter",
+    "LogLevel",
+    "TextFormatter",
+    "configure_uvicorn_logging",
+    "init_logging",
+]

--- a/app_backend/app/telemetry/logging.py
+++ b/app_backend/app/telemetry/logging.py
@@ -1,0 +1,125 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import sys
+import time
+import traceback
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable, Dict, Literal, Union
+
+
+class LogLevel(str, Enum):
+    ERROR = "ERROR"
+    WARN = "WARNING"
+    WARNING = "WARNING"
+    INFO = "INFO"
+    DEBUG = "DEBUG"
+
+
+FormatType = Literal["json", "text"]
+
+_STANDARD_LOG_RECORD_ATTRS = set(
+    logging.LogRecord("", 0, "", 0, "", (), None).__dict__.keys()
+)
+_OTHER_LOG_RECORD_ATTRS = set({"asctime", "message", "color_message"})
+_ALL_EXCLUDED_LOG_RECORD_ATTRS = _STANDARD_LOG_RECORD_ATTRS.union(
+    _OTHER_LOG_RECORD_ATTRS
+)
+
+
+class JsonFormatter(logging.Formatter):
+    """JSON formatter that includes explicitly provided extra fields."""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.default_fields: Dict[
+            str, Union[Callable[[logging.LogRecord], Any], Any]
+        ] = {
+            "timestamp": lambda _: datetime.now(timezone.utc).isoformat(),
+            "level": lambda record: record.levelname,
+            "logger": lambda record: record.name,
+        }
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_data = {
+            field: getter(record) if callable(getter) else getter
+            for field, getter in self.default_fields.items()
+        }
+        log_data["message"] = record.getMessage()
+
+        if record.exc_info and record.exc_info[0]:
+            log_data["exception"] = {
+                "type": record.exc_info[0].__name__,
+                "message": str(record.exc_info[1]),
+                "traceback": "".join(traceback.format_exception(*record.exc_info)),
+            }
+
+        extra_fields = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in _ALL_EXCLUDED_LOG_RECORD_ATTRS
+        }
+        for key, value in extra_fields.items():
+            try:
+                json.dumps(value, default=str)
+                log_data[key] = value
+            except ValueError as e:
+                log_data[key] = f"<serialization error: {str(e)}>"
+
+        return json.dumps(log_data, ensure_ascii=False, default=str)
+
+
+class TextFormatter(logging.Formatter):
+    """Text formatter that appends explicitly provided extra fields."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = super().format(record)
+        extra_fields = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in _ALL_EXCLUDED_LOG_RECORD_ATTRS
+        }
+        if extra_fields:
+            extra_str = " | ".join(
+                f"{key}={value}" for key, value in extra_fields.items()
+            )
+            message = f"{message} | {extra_str}"
+        return message
+
+
+def init_logging(
+    level: LogLevel = LogLevel.INFO,
+    format_type: FormatType = "text",
+    stream: Any = sys.stdout,
+) -> None:
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level.value)
+
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+
+    handler = logging.StreamHandler(stream)
+    if format_type == "json":
+        handler.setFormatter(JsonFormatter())
+    else:
+        text_formatter = TextFormatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        text_formatter.converter = time.gmtime
+        handler.setFormatter(text_formatter)
+
+    root_logger.addHandler(handler)

--- a/app_backend/app/telemetry/uvicorn_filter.py
+++ b/app_backend/app/telemetry/uvicorn_filter.py
@@ -1,0 +1,69 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from .logging import JsonFormatter, TextFormatter
+
+
+class HealthCheckFilter(logging.Filter):
+    """Filter out health check requests from access logs."""
+
+    def __init__(self, log_level: str = "INFO"):
+        super().__init__()
+        self.log_level = log_level
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        numeric_log_level = getattr(logging, self.log_level.upper())
+        if numeric_log_level <= logging.DEBUG:
+            return True
+
+        message = record.getMessage()
+        return not ("/health" in message and "GET" in message)
+
+
+def configure_uvicorn_logging(
+    log_format: str = "text", log_level: str = "INFO"
+) -> None:
+    """Configure uvicorn logging to use application formatters."""
+    access_logger = logging.getLogger("uvicorn.access")
+    access_logger.handlers.clear()
+
+    handler = logging.StreamHandler()
+    if log_format == "json":
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(
+            TextFormatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        )
+    handler.addFilter(HealthCheckFilter(log_level))
+
+    access_logger.addHandler(handler)
+    access_logger.setLevel(getattr(logging, log_level.upper()))
+    access_logger.propagate = False
+
+    error_logger = logging.getLogger("uvicorn.error")
+    error_logger.handlers.clear()
+
+    handler = logging.StreamHandler()
+    if log_format == "json":
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(
+            TextFormatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        )
+
+    error_logger.addHandler(handler)
+    error_logger.setLevel(getattr(logging, log_level.upper()))
+    error_logger.propagate = False

--- a/app_backend/tests/conftest.py
+++ b/app_backend/tests/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+for path in (APP_BACKEND_ROOT, REPO_ROOT):
+    path_text = str(path)
+    if path_text not in sys.path:
+        sys.path.insert(0, path_text)

--- a/app_backend/tests/test_v1151_fastapi_app_factory.py
+++ b/app_backend/tests/test_v1151_fastapi_app_factory.py
@@ -80,11 +80,16 @@ def test_backend_package_exposes_app_factory(
 ) -> None:
     _set_required_import_env(monkeypatch)
 
-    from core.rest_api import app as core_app
-
     from app import create_app
 
-    assert create_app() is core_app
+    created_app = create_app()
+
+    assert created_app is create_app()
+    assert any(
+        getattr(route, "path", "") == "/api/v1/config/feature-flags"
+        for route in created_app.routes
+    )
+    assert any(getattr(route, "path", "") == "/health" for route in created_app.routes)
 
 
 def test_backend_main_app_uses_core_factory(

--- a/app_backend/tests/test_v1151_fastapi_integration.py
+++ b/app_backend/tests/test_v1151_fastapi_integration.py
@@ -1,0 +1,72 @@
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _set_required_import_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "test-token")
+    monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://example.com")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+
+
+def test_backend_app_exposes_health_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_import_env(monkeypatch)
+
+    from app import create_app
+
+    response = TestClient(create_app()).get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+def test_backend_app_lifespan_initializes_deps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_import_env(monkeypatch)
+
+    from app import create_app
+    from app.config import Config
+    from app.deps import Deps
+
+    deps = Deps(config=Config(log_format="text"))
+
+    with TestClient(create_app(deps=deps)) as client:
+        assert client.app.state.deps is deps
+
+
+def test_core_app_factory_accepts_lifespan_without_reusing_singleton(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_import_env(monkeypatch)
+
+    from core import rest_api
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+        app.state.integration_marker = "ready"
+        yield
+
+    created_app = rest_api.create_app(lifespan=lifespan, title="Injected API")
+
+    assert created_app is not rest_api.app
+    assert created_app.title == "Injected API"
+    with TestClient(created_app) as client:
+        assert client.app.state.integration_marker == "ready"
+
+
+def test_session_helpers_are_extracted_and_reexported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_import_env(monkeypatch)
+
+    from core import middleware, rest_api
+
+    assert rest_api.SessionState is middleware.SessionState
+    assert rest_api.session_store is middleware.session_store
+    assert rest_api._initialize_session is middleware._initialize_session

--- a/core/src/core/middleware.py
+++ b/core/src/core/middleware.py
@@ -1,0 +1,206 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Middleware components for the Data Analyst API."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import uuid
+from copy import deepcopy
+from pathlib import Path
+from tempfile import gettempdir
+from typing import Any
+
+import datarobot as dr
+from fastapi import Request, Response
+
+from core.analyst_db import AnalystDB
+from core.data_analyst_telemetry import telemetry
+from core.datarobot_client import use_user_token
+from core.logging_helper import get_logger
+
+logger = get_logger()
+
+
+class SessionState(object):
+    """Session state container for user-specific data."""
+
+    _state: dict[str, Any]
+
+    def __init__(self, state: dict[str, Any] | None = None):
+        if state is None:
+            state = {}
+        super().__setattr__("_state", state)
+
+    def __setattr__(self, key: Any, value: Any) -> None:
+        self._state[key] = value
+
+    def __getattr__(self, key: Any) -> Any:
+        try:
+            return self._state[key]
+        except KeyError:
+            message = "'{}' object has no attribute '{}'"
+            raise AttributeError(message.format(self.__class__.__name__, key))
+
+    def __delattr__(self, key: Any) -> None:
+        del self._state[key]
+
+    def update(self, state: dict[str, Any]) -> None:
+        self._state.update(state)
+
+
+session_store: dict[str, SessionState] = {}
+session_lock = asyncio.Lock()
+
+
+async def get_database(user_id: str) -> AnalystDB:
+    """Create an AnalystDB instance for the given user."""
+    analyst_db = await AnalystDB.create(
+        user_id=user_id,
+        db_path=Path(gettempdir()),
+        dataset_db_name="datasets.db",
+        chat_db_name="chat.db",
+        data_source_db_name="datasources.db",
+        user_recipe_db_name="recipe.db",
+        use_persistent_storage=bool(os.environ.get("APPLICATION_ID")),
+    )
+    return analyst_db
+
+
+@telemetry.trace
+@telemetry.meter
+async def _initialize_session(
+    request: Request,
+) -> tuple[
+    SessionState,
+    str | None,
+    str | None,
+]:
+    """Initialize the session state and return the session ID and user ID."""
+    test_user_email = os.environ.get("TEST_USER_EMAIL", "")
+
+    if test_user_email and os.environ.get("APPLICATION_ID"):
+        logger.fatal("TEST_USER_EMAIL is set on a deployed instance.")
+        raise RuntimeError("TEST_USER_EMAIL is set on a deployed instance.")
+
+    is_local_dev = os.environ.get("DEV_MODE", False)
+    session_state = SessionState()
+    empty_session_state: dict[str, Any] = {
+        "datarobot_account_info": None,
+        "datarobot_api_scoped_token": os.environ.get("DATAROBOT_API_TOKEN")
+        if is_local_dev
+        else None,
+        "analyst_db": None,
+    }
+    session_state.update(deepcopy(empty_session_state))
+
+    user_id = None
+    session_fastapi_cookie = request.cookies.get("session_fastapi")
+    if session_fastapi_cookie:
+        try:
+            user_id = base64.b64decode(session_fastapi_cookie.encode()).decode()
+        except Exception:
+            pass
+
+    new_user_id = None
+    email_header = request.headers.get("x-user-email")
+    if email_header:
+        new_user_id = str(uuid.uuid5(uuid.NAMESPACE_OID, email_header))[:36]
+    elif test_user_email:
+        new_user_id = str(uuid.uuid5(uuid.NAMESPACE_OID, test_user_email))[:36]
+
+    session_id = None
+    if session_fastapi_cookie:
+        session_id = session_fastapi_cookie
+    elif new_user_id:
+        session_id = base64.b64encode(new_user_id.encode()).decode()
+
+    if session_id:
+        async with session_lock:
+            existing_session = session_store.get(session_id)
+            if existing_session:
+                return existing_session, session_id, user_id or new_user_id
+            session_store[session_id] = session_state
+
+    return session_state, session_id, user_id or new_user_id
+
+
+async def _initialize_database(request: Request, user_id: str) -> None:
+    """Initialize per-user database in the session if not already initialized."""
+    if (
+        not hasattr(request.state.session, "analyst_db")
+        or request.state.session.analyst_db is None
+    ):
+        async with session_lock:
+            request.state.session.analyst_db = await get_database(user_id)
+
+
+def _set_session_cookie(
+    response: Response,
+    user_id: str | None,
+    session_id: str,
+    session_fastapi_cookie: str | None,
+) -> None:
+    """Set the session cookie if needed."""
+    if user_id and not session_fastapi_cookie:
+        encoded_uid = base64.b64encode(user_id.encode()).decode()
+        response.set_cookie(key="session_fastapi", value=encoded_uid, httponly=True)
+    elif not session_fastapi_cookie and not user_id:
+        response.set_cookie(key="session_fastapi", value=session_id, httponly=True)
+
+
+async def session_middleware(request: Request, call_next):  # type: ignore[no-untyped-def]
+    """Middleware to manage user sessions."""
+    request_methods = ["GET", "POST", "PUT", "PATCH", "DELETE"]
+    session_id: str | None = None
+    user_id: str | None = None
+
+    if request.method in request_methods:
+        session_state, session_id, user_id = await _initialize_session(request)
+        request.state.session = session_state
+
+        if not request.state.session.datarobot_account_info:
+            request.state.session.datarobot_account_info = {}
+            try:
+                if request.headers.get("x-user-email"):
+                    with use_user_token(request):
+                        reply = dr.client.get_client().get("account/info/")
+                        account_info = reply.json()
+                    request.state.session.datarobot_account_info = account_info
+                elif os.environ.get("TEST_USER_EMAIL", ""):
+                    reply = dr.client.get_client().get("account/info/")
+                    account_info = reply.json()
+                    request.state.session.datarobot_account_info = account_info
+            except Exception as e:
+                logger.info(f"Error fetching account info: {e}")
+
+        dr_uid = request.state.session.datarobot_account_info.get("uid")
+        if session_id is None and dr_uid is not None:
+            session_id = base64.b64encode(dr_uid.encode()).decode()
+            user_id = dr_uid
+
+        if user_id:
+            await _initialize_database(request, user_id)
+
+    response: Response = await call_next(request)
+
+    if request.method in request_methods and session_id:
+        _set_session_cookie(
+            response, user_id, session_id, request.cookies.get("session_fastapi")
+        )
+
+    return response

--- a/core/src/core/rest_api.py
+++ b/core/src/core/rest_api.py
@@ -14,19 +14,14 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import io
 import json
 import os
 import sys
 import tempfile
-import uuid
-from copy import deepcopy
-from pathlib import Path
 from typing import Any, Iterable, List, Union, cast
 
 import chardet
-import datarobot as dr
 import pandas as pd
 from fastapi import (
     APIRouter,
@@ -50,7 +45,9 @@ from openpyxl import Workbook
 from openpyxl.drawing.image import Image as XLImage
 from openpyxl.utils.dataframe import dataframe_to_rows
 from starlette.background import BackgroundTask
+from starlette.types import Lifespan
 
+from core import middleware as core_middleware
 from core.analyst_db import (
     AnalystDB,
     DatasetMetadata,
@@ -118,6 +115,13 @@ from core.token_tracking import (
 logger = get_logger()
 
 MAX_EXCEL_ROWS = 50000  # Maximum rows to export to Excel to prevent memory issues
+
+# Backward-compatible exports for utils.rest_api/core.rest_api consumers.
+SessionState = core_middleware.SessionState
+_initialize_session = core_middleware._initialize_session
+get_database = core_middleware.get_database
+session_middleware = core_middleware.session_middleware
+session_store = core_middleware.session_store
 
 
 def detect_and_decode_csv(raw_bytes: bytes, filename: str) -> str:
@@ -276,19 +280,6 @@ def _chart_trace_to_dataframe(trace: dict[str, Any]) -> pd.DataFrame:
     return df
 
 
-async def get_database(user_id: str) -> AnalystDB:
-    analyst_db = await AnalystDB.create(
-        user_id=user_id,
-        db_path=Path("/tmp"),
-        dataset_db_name="datasets.db",
-        chat_db_name="chat.db",
-        data_source_db_name="datasources.db",
-        user_recipe_db_name="recipe.db",
-        use_persistent_storage=bool(os.environ.get("APPLICATION_ID")),
-    )
-    return analyst_db
-
-
 # Dependency to provide the initialized database
 async def get_initialized_db(request: Request) -> AnalystDB:
     if (
@@ -305,53 +296,76 @@ async def get_initialized_db(request: Request) -> AnalystDB:
     return cast(AnalystDB, request.state.session.analyst_db)
 
 
-# Initialize FastAPI app
-app = FastAPI(
-    title="Data Analyst API",
-    description="""
-    An intelligent API for data analysis that provides capabilities including:
-    - Dataset management (upload CSV/Excel files, connect to databases, access the Data Registry)
-    - Data cleansing and standardization
-    - Data dictionary creation and management
-    - Chat-based data analysis conversations
-    - Python code generation
-    - Chart creation
-    - Business insights generation
-
-    Available endpoint groups:
-    - /api/v1/registry: Access Data Registry datasets
-    - /api/v1/database: Database connection and table management
-    - /api/v1/datasets: Upload, retrieve, and manage datasets
-    - /api/v1/dictionaries: Manage data dictionaries
-    - /api/v1/chats: Create and manage chat conversations for data analysis
-
-    The API uses OpenAI's GPT models for intelligent analysis and response generation.
-    """,
-    version="1.0.0",
-    contact={"name": "API Support", "email": "support@example.com"},
-    license_info={
-        "name": "Apache 2.0",
-        "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
-    },
-    debug=True,  # Stack traces will be exposed for 500 responses
-)
-
-
 script_name = os.environ.get("SCRIPT_NAME", "")
 router = APIRouter(prefix=f"{script_name}/api/v1")
+_app_singleton: FastAPI | None = None
 
-# Add CORS middleware
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],  # Allows all origins
-    allow_credentials=True,
-    allow_methods=["*"],  # Allows all methods
-    allow_headers=["*"],  # Allows all headers
-)
+
+def _create_fastapi_app(
+    lifespan: Lifespan[FastAPI] | None = None,
+    title: str = "Data Analyst API",
+) -> FastAPI:
+    created_app = FastAPI(
+        title=title,
+        description="""
+        An intelligent API for data analysis that provides capabilities including:
+        - Dataset management (upload CSV/Excel files, connect to databases, access the Data Registry)
+        - Data cleansing and standardization
+        - Data dictionary creation and management
+        - Chat-based data analysis conversations
+        - Python code generation
+        - Chart creation
+        - Business insights generation
+
+        Available endpoint groups:
+        - /api/v1/registry: Access Data Registry datasets
+        - /api/v1/database: Database connection and table management
+        - /api/v1/datasets: Upload, retrieve, and manage datasets
+        - /api/v1/dictionaries: Manage data dictionaries
+        - /api/v1/chats: Create and manage chat conversations for data analysis
+
+        The API uses OpenAI's GPT models for intelligent analysis and response generation.
+        """,
+        version="1.0.0",
+        contact={"name": "API Support", "email": "support@example.com"},
+        license_info={
+            "name": "Apache 2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+        },
+        lifespan=lifespan,
+        debug=True,  # Stack traces will be exposed for 500 responses
+    )
+
+    created_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    created_app.middleware("http")(session_middleware)
+    created_app.openapi = lambda: custom_openapi(created_app)  # type: ignore[method-assign]
+    created_app.include_router(router)
+
+    try:
+        from core.customize.rest_api import router as customize_router
+
+        created_app.include_router(customize_router, prefix=f"{script_name}/api/v1")
+        logger.info("Customize API endpoints mounted")
+    except ImportError as e:
+        logger.warning("Customize module was not found: %s", e)
+    except Exception as e:
+        logger.exception("Failed to load customize API endpoints: %s", e)
+
+    telemetry.log_application_start()
+    telemetry.instrument_fastapi_app(created_app)
+
+    return created_app
 
 
 # Add custom OpenAPI schema
-def custom_openapi() -> dict[str, Any]:
+def custom_openapi(app: FastAPI) -> dict[str, Any]:
     if app.openapi_schema:
         return app.openapi_schema
 
@@ -371,163 +385,19 @@ def custom_openapi() -> dict[str, Any]:
     return app.openapi_schema
 
 
-app.openapi = custom_openapi  # type: ignore[method-assign]
+def create_app(
+    lifespan: Lifespan[FastAPI] | None = None,
+    title: str = "Data Analyst API",
+) -> FastAPI:
+    """Create a configured FastAPI app, preserving the default singleton."""
+    global _app_singleton
 
+    if lifespan is None and title == "Data Analyst API":
+        if _app_singleton is None:
+            _app_singleton = _create_fastapi_app()
+        return _app_singleton
 
-def create_app() -> FastAPI:
-    """Return the configured FastAPI application singleton."""
-    return app
-
-
-class SessionState(object):
-    _state: dict[str, Any]
-
-    def __init__(self, state: dict[str, Any] | None = None):
-        if state is None:
-            state = {}
-        super().__setattr__("_state", state)
-
-    def __setattr__(self, key: Any, value: Any) -> None:
-        self._state[key] = value
-
-    def __getattr__(self, key: Any) -> Any:
-        try:
-            return self._state[key]
-        except KeyError:
-            message = "'{}' object has no attribute '{}'"
-            raise AttributeError(message.format(self.__class__.__name__, key))
-
-    def __delattr__(self, key: Any) -> None:
-        del self._state[key]
-
-    def update(self, state: dict[str, Any]) -> None:
-        self._state.update(state)
-
-
-session_store: dict[str, SessionState] = {}
-session_lock = asyncio.Lock()
-
-
-@app.middleware("http")
-async def add_session_middleware(request: Request, call_next):  # type: ignore[no-untyped-def]
-    request_methods = ["GET", "POST", "PUT", "PATCH", "DELETE"]
-    if request.method in request_methods:
-        # Initialize the session
-        session_state, session_id, user_id = await _initialize_session(request)
-        request.state.session = session_state
-
-        if not request.state.session.datarobot_account_info:
-            request.state.session.datarobot_account_info = {}
-            try:
-                if request.headers.get("x-user-email"):
-                    # do not try to fetch user info for prob requests
-                    with use_user_token(request):
-                        reply = dr.client.get_client().get("account/info/")
-                        account_info = reply.json()
-                    request.state.session.datarobot_account_info = account_info
-            except Exception as e:
-                logger.info(f"Error fetching account info: {e}")
-
-        dr_uid = request.state.session.datarobot_account_info.get("uid")
-        if session_id is None and dr_uid is not None:
-            session_id = base64.b64encode(dr_uid.encode()).decode()
-            user_id = dr_uid
-
-        # Initialize database in the session
-        if user_id:
-            await _initialize_database(request, user_id)
-
-    # Process the request
-    response: Response = await call_next(request)
-
-    if request.method in request_methods:
-        # Set session cookie if needed
-        if session_id:
-            _set_session_cookie(
-                response, user_id, session_id, request.cookies.get("session_fastapi")
-            )
-
-    return response
-
-
-@telemetry.trace
-@telemetry.meter
-async def _initialize_session(
-    request: Request,
-) -> tuple[
-    SessionState,
-    str | None,
-    str | None,
-]:
-    """Initialize the session state and return the session ID and user ID."""
-    # Create a new session state with default values
-    is_local_dev = os.environ.get("DEV_MODE", False)
-    session_state = SessionState()
-    empty_session_state: dict[str, Any] = {
-        "datarobot_account_info": None,
-        "datarobot_api_scoped_token": os.environ.get("DATAROBOT_API_TOKEN")
-        if is_local_dev
-        else None,
-        "analyst_db": None,
-    }
-    session_state.update(deepcopy(empty_session_state))
-
-    # Try to get user ID from cookie
-    user_id = None
-    session_fastapi_cookie = request.cookies.get("session_fastapi")
-    if session_fastapi_cookie:
-        try:
-            user_id = base64.b64decode(session_fastapi_cookie.encode()).decode()
-        except Exception:
-            pass  # If decoding fails, continue without user_id
-
-    # Generate a new user ID if needed
-    new_user_id = None
-    email_header = request.headers.get("x-user-email")
-    if email_header:
-        new_user_id = str(uuid.uuid5(uuid.NAMESPACE_OID, email_header))[:36]
-
-    # Determine session ID
-    session_id = None
-    if session_fastapi_cookie:
-        session_id = session_fastapi_cookie
-    elif new_user_id:
-        session_id = base64.b64encode(new_user_id.encode()).decode()
-
-    # Get or create session in store
-    if session_id:
-        async with session_lock:
-            existing_session = session_store.get(session_id)
-            if existing_session:
-                return existing_session, session_id, user_id or new_user_id
-            else:
-                session_store[session_id] = session_state
-
-    return session_state, session_id, user_id or new_user_id
-
-
-async def _initialize_database(request: Request, user_id: str) -> None:
-    """Initialize per-user database in the session if not already initialized."""
-    if (
-        not hasattr(request.state.session, "analyst_db")
-        or request.state.session.analyst_db is None
-    ):
-        async with session_lock:
-            request.state.session.analyst_db = await get_database(user_id)
-
-
-def _set_session_cookie(
-    response: Response,
-    user_id: str | None,
-    session_id: str,
-    session_fastapi_cookie: str | None,
-) -> None:
-    """Set the session cookie if needed."""
-    if user_id and not session_fastapi_cookie:
-        encoded_uid = base64.b64encode(user_id.encode()).decode()
-        response.set_cookie(key="session_fastapi", value=encoded_uid, httponly=True)
-    elif not session_fastapi_cookie and not user_id:
-        response.set_cookie(key="session_fastapi", value=session_id, httponly=True)
+    return _create_fastapi_app(lifespan=lifespan, title=title)
 
 
 # Make this sync as the DR requests are synchronous, if async this would block.
@@ -2010,16 +1880,4 @@ async def store_datarobot_account(
     return {"success": True}
 
 
-# メインルーターの追加
-app.include_router(router)
-
-# カスタマイズAPIの統合
-try:
-    from core.customize.rest_api import router as customize_router
-
-    app.include_router(customize_router, prefix="/api/v1")
-    print("✅ カスタマイズAPIエンドポイントを追加しました")
-except ImportError as e:
-    print(f"⚠️ カスタマイズモジュールが見つかりません: {e}")
-except Exception as e:
-    print(f"❌ カスタマイズモジュールの読み込みに失敗しました: {e}")
+app = create_app()

--- a/customize_docs/v11_5_1_integration_plan.md
+++ b/customize_docs/v11_5_1_integration_plan.md
@@ -239,9 +239,11 @@ PR2 の core package mechanical migration で、top-level 依存も切り替え�
 
 - `app_backend/app/__init__.py`
 - `app_backend/app/main.py`
+- `app_backend/app/config.py`
 - `app_backend/app/deps.py`
-- `app_backend/app/middleware.py`
-- `app_backend/app/routers/*`
+- `app_backend/app/telemetry/*`
+- `core/src/core/rest_api.py`
+- `core/src/core/middleware.py`
 
 先に追加・更新するテスト:
 
@@ -261,8 +263,13 @@ PR2 の core package mechanical migration で、top-level 依存も切り替え�
 - `app_backend/app/main.py` は `utils.rest_api.app` の直接 import から `core.rest_api.create_app()` 呼び出しへ切り替えた。
 - このPRでは router 分割や deps/middleware の本格移植は行わない。customize routes、static frontend fallback、既存 session middleware を保ったまま、後続PRで `app_backend/app/__init__.py` に upstream の thin app 構成を取り込める入口だけ固定する。
 - 2026-06-12: static frontend / runtime env script / telemetry setup を `app_backend/app/__init__.py` の `create_app()` に移し、`app_backend/app/main.py` を `from app import create_app; app = create_app()` の thin entrypoint にした。
-- `create_app()` は既存の `core.rest_api` singleton を再利用し、重複 mount を避けるため app_backend 側でも configured app を cache する。upstream の deps/lifespan と DataRobot ASGI middleware は、既存 session middleware と conflict しない形を確認してから別PRで取り込む。
+- 2026-06-12 時点では `create_app()` が既存の `core.rest_api` singleton を再利用し、重複 mount を避けるため app_backend 側でも configured app を cache していた。upstream の deps/lifespan と DataRobot ASGI middleware は、既存 session middleware と conflict しない形を確認してから後続で取り込む前提だった。
 - 2026-06-15: `dev` 向けまとめPRの `FastAPI: app_backend` CI は `app_backend/` を cwd として実行するため、entrypoint 構造テストの source file path を `__file__` 起点に変更した。
+- 2026-06-15: upstream `v11.5.1` の `Config` / `Deps` / lifespan 初期化を `app_backend/app` に追加した。`create_app(deps=...)` で injected deps を `app.state.deps` に設定できる。
+- 2026-06-15: `/health` と DataRobot ASGI middleware 境界を `app_backend/app/__init__.py` に追加した。ローカルの未同期環境でも backend import が失敗しないよう、`datarobot-asgi-middleware` がない場合は警告に留める。
+- 2026-06-15: session middleware を `core/src/core/middleware.py` に分離し、`utils.rest_api` / `core.rest_api` からの既存参照は re-export で維持した。upstream の `TEST_USER_EMAIL` 対応を取り込みつつ、`DEV_MODE` 時の `DATAROBOT_API_TOKEN` scoped token 互換は残した。
+- 2026-06-15: `core.rest_api.create_app(lifespan=..., title=...)` は fresh FastAPI app を作れるようにし、引数なしでは従来どおり `core.rest_api.app` singleton を返す。backend 側 `create_app()` は lifespan 付き configured app を cache する。
+- 2026-06-15: upstream `v11.5.1` の router split は実ファイル上 `core/src/core/routers/*` だが、既存 customize import (`get_initialized_db`, `run_complete_analysis_task`) と backend monkeypatch テストを壊さないため、今回のPRでは既存 monolithic router を factory に載せ替える形で統合した。
 
 ### PR4: LLM configuration / LiteLLM integration
 


### PR DESCRIPTION
## Summary
- Add the upstream-style backend `Config` / `Deps` / lifespan setup and `/health` route while preserving static frontend fallback and `_dr_env.js` behavior.
- Extract session middleware into `core.middleware` and re-export the existing `core.rest_api` / `utils.rest_api` compatibility surface.
- Allow `core.rest_api.create_app(lifespan=..., title=...)` to create fresh apps while keeping the no-arg singleton behavior.
- Document the PR3 completion notes in `customize_docs/v11_5_1_integration_plan.md`.

## Testing
- `uv run pytest app_backend/tests customize_docs -q`
- `uv run ruff check app_backend/app app_backend/tests core/src/core/rest_api.py core/src/core/middleware.py`
- `uv run ruff format --check app_backend/app app_backend/tests core/src/core/rest_api.py core/src/core/middleware.py`

## Notes
- Polars-to-pandas migration is intentionally not included.
- The upstream `core/src/core/routers/*` split is kept as a behavior-neutral follow-up candidate; this PR moves the middleware/factory boundary without breaking existing endpoint imports or monkeypatch tests.
