### PR TITLE
[codex] Add infra Taskfile deployment entrypoints

### DIFF
--- a/.datarobot/cli/base.yml
+++ b/.datarobot/cli/base.yml
@@ -15,6 +15,11 @@ root:
         value: "react"
       - name: "streamlit"
         value: "streamlit"
+  - env: DATAROBOT_DEFAULT_USE_CASE
+    type: string
+    default:
+    optional: true
+    help: "Enter the default use case for this application. If not set, a new use case will be created automatically."
   - env: USE_DATAROBOT_LLM_GATEWAY
     type: "boolean"
     help: "Use LLM Gateway instead of DataRobot-hosted LLM. If you select this, you do not need any credentials for your DataRobot-hosted LLM since it will use your DataRobot credentials instead."
@@ -26,24 +31,21 @@ root:
       - name: "No"
         value: "false"
         requires: "datarobot_hosted_llm"
-  - key: "enable_snowflake"
-    help: "Do you want to configure Snowflake?"
+  - env: DATABASE_CONNECTION_TYPE
+    type: string
+    help: Do you want to enable an external database connection?
+    default: None
     options:
-      - name: "No"
-      - name: "Yes"
-        requires: "snowflake_config"
-  - key: "enable_bigquery"
-    help: "Do you want to configure BigQuery?"
-    options:
-      - name: "No"
-      - name: "Yes"
-        requires: "bigquery_config"
-  - key: "enable_sap_datasphere"
-    help: "Do you want to configure SAP DataSphere?"
-    options:
-      - name: "No"
-      - name: "Yes"
-        requires: "sap_datasphere_config"
+      - name: None
+      - name: Snowflake
+        value: snowflake
+        requires: snowflake_config
+      - name: BigQuery
+        value: bigquery
+        requires: bigquery_config
+      - name: SAP Datasphere
+        value: sap
+        requires: sap_datasphere_config
 
 datarobot_hosted_llm:
   - key: "enable_google_vertexai"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -9,6 +9,9 @@ includes:
   app_frontend:
     taskfile: ./app_frontend/Taskfile.yaml
     dir: ./app_frontend
+  infra:
+    taskfile: ./infra/Taskfile.yaml
+    dir: ./infra
 tasks:
   default:
     desc: "ℹ️ Show all available tasks (run `task --list-all` to see hidden tasks)"
@@ -17,11 +20,13 @@ tasks:
     silent: true
 
   start:
-    desc: "🚀 Quickstart"
+    desc: "💻 Prepare local development environment"
     cmds:
       - dr self update
       - dr dotenv setup --if-needed
-      - python quickstart.py
+      - task install
+      - task infra:start
+      - echo '✅ You are all set. Run `task dev` to start developing, or run `task deploy-dev` to deploy to DataRobot.'
 
   lint:
     desc: "🧹 Run linters"
@@ -33,6 +38,7 @@ tasks:
     cmds:
       - task: app_backend:install
       - task: app_frontend:install
+      - task: infra:install
 
   reinstall:
     desc: "🛠️ Reinstall all dependencies (placeholder task)"
@@ -58,3 +64,13 @@ tasks:
         echo "🔗 Backend: ${prefix}8080"
         echo "🔗 Frontend: ${prefix}5173"
         wait
+
+  deploy:
+    desc: "🚀 Deploy all services"
+    cmds:
+      - task: infra:deploy
+
+  deploy-dev:
+    desc: "🚀 Deploy infrastructure and services to development"
+    cmds:
+      - task: infra:deploy-dev

--- a/customize_docs/test_custom_job_schedule_resource.py
+++ b/customize_docs/test_custom_job_schedule_resource.py
@@ -32,6 +32,17 @@ def test_pulumi_stack_does_not_manage_custom_job_schedule() -> None:
     assert "CUSTOM_JOB_SCHEDULE_ID" not in stack_source
 
 
+def test_pulumi_stack_keeps_optional_resource_guards() -> None:
+    stack_source = (Path(__file__).parents[1] / "infra" / "__main__.py").read_text()
+
+    assert "FEATURE_FLAG_ENV_VARS.values()" in stack_source
+    assert "DISALLOW_MONITORING_RESOURCES" in stack_source
+    assert "SKIP_PULUMI_CUSTOM_JOBS" in stack_source
+    assert "DISALLOW_APP_CLEANUP_JOB" in stack_source
+    assert "create_monitoring_resources()" in stack_source
+    assert "create_cleanup_job(app)" in stack_source
+
+
 def test_settings_job_infra_does_not_build_deploy_schedule(settings_job_infra) -> None:
     assert not hasattr(settings_job_infra, "get_job_schedule")
     assert not hasattr(settings_job_infra, "create_job_schedule")

--- a/customize_docs/test_pulumi_workflow_refresh.py
+++ b/customize_docs/test_pulumi_workflow_refresh.py
@@ -93,4 +93,21 @@ def test_pulumi_up_workflow_refreshes_stack_before_update() -> None:
         assert step["env"]["SKIP_PULUMI_FRONTEND_BUILD"] == "true"
         assert step["env"]["SKIP_PULUMI_CUSTOM_JOBS"] == "true"
         assert step["env"]["DISALLOW_MONITORING_RESOURCES"] == "true"
+        assert "VITE_ENABLE_REPORT_BUILDER" in step["env"]
         assert "SCHEDULER_HOUR" not in step["env"]
+
+
+def test_python_unit_workflow_runs_backend_and_customize_docs_tests() -> None:
+    workflow_path = (
+        Path(__file__).parents[1] / ".github" / "workflows" / "python-unit-tests.yml"
+    )
+    workflow = yaml.safe_load(workflow_path.read_text())
+
+    steps = workflow["jobs"]["test"]["steps"]
+    run_tests_step = next(
+        (step for step in steps if step.get("name") == "Run tests"),
+        None,
+    )
+
+    assert run_tests_step is not None
+    assert "pytest app_backend/tests customize_docs -q" in run_tests_step["run"]

--- a/customize_docs/test_taskfile_deployment_dx.py
+++ b/customize_docs/test_taskfile_deployment_dx.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).parents[1]
+
+
+def _load_yaml(relative_path: str) -> dict[str, Any]:
+    return yaml.safe_load((REPO_ROOT / relative_path).read_text())
+
+
+def test_root_taskfile_exposes_infra_deploy_entrypoints() -> None:
+    taskfile = _load_yaml("Taskfile.yaml")
+
+    assert taskfile["includes"]["infra"] == {
+        "taskfile": "./infra/Taskfile.yaml",
+        "dir": "./infra",
+    }
+    assert taskfile["tasks"]["deploy"]["cmds"] == [{"task": "infra:deploy"}]
+    assert taskfile["tasks"]["deploy-dev"]["cmds"] == [{"task": "infra:deploy-dev"}]
+
+
+def test_infra_taskfile_keeps_existing_root_pulumi_project() -> None:
+    taskfile = _load_yaml("infra/Taskfile.yaml")
+
+    assert taskfile["tasks"]["deploy"]["dir"] == ".."
+    assert taskfile["tasks"]["deploy-dev"]["dir"] == ".."
+    assert taskfile["tasks"]["refresh"]["dir"] == ".."
+    assert taskfile["tasks"]["select"]["dir"] == ".."
+    assert any(
+        "uv run pulumi up" in command
+        for command in taskfile["tasks"]["deploy"]["cmds"]
+        if isinstance(command, str)
+    )
+    assert any(
+        "--target" in command
+        for command in taskfile["tasks"]["deploy-dev"]["cmds"]
+        if isinstance(command, str)
+    )
+
+
+def test_cli_base_uses_runtime_database_connection_selection() -> None:
+    cli_base = _load_yaml(".datarobot/cli/base.yml")
+    root_entries = cli_base["root"]
+    env_entries = {
+        entry["env"]: entry
+        for entry in root_entries
+        if isinstance(entry, dict) and "env" in entry
+    }
+    key_entries = {
+        entry["key"]: entry
+        for entry in root_entries
+        if isinstance(entry, dict) and "key" in entry
+    }
+
+    assert "DATAROBOT_DEFAULT_USE_CASE" in env_entries
+    assert env_entries["DATAROBOT_DEFAULT_USE_CASE"]["optional"] is True
+    assert "DATABASE_CONNECTION_TYPE" in env_entries
+    assert {
+        option.get("value", option["name"])
+        for option in env_entries["DATABASE_CONNECTION_TYPE"]["options"]
+    } == {"None", "snowflake", "bigquery", "sap"}
+    assert "enable_snowflake" not in key_entries
+    assert "enable_bigquery" not in key_entries
+    assert "enable_sap_datasphere" not in key_entries

--- a/customize_docs/v11_5_1_integration_plan.md
+++ b/customize_docs/v11_5_1_integration_plan.md
@@ -332,6 +332,14 @@ PR2 の core package mechanical migration で、top-level 依存も切り替え�
 - `uv run ruff check infra`
 - `task --list --sort none`
 
+実装メモ:
+
+- 2026-06-15: PR5 用ブランチ `codex/pr5-infra-taskfile-deployment-dx` を `origin/dev` から作成した。
+- 2026-06-15: RED として `customize_docs/test_taskfile_deployment_dx.py` を追加し、root `Taskfile.yaml` の `infra` include、`deploy` / `deploy-dev`、既存 root `Pulumi.yaml` を使う `infra/Taskfile.yaml`、CLI の `DATABASE_CONNECTION_TYPE` 選択を固定した。
+- 2026-06-15: upstream `v11.5.1` の `infra/Pulumi.yaml` / `infra/infra/*` への大移動は、現行 `pulumi-up.yml` と既存 `infra/settings_*` 構成への影響が大きいためこの PR では見送る。代わりに `infra/Taskfile.yaml` の各 Pulumi タスクを `dir: ..` で実行し、既存 root Pulumi project を維持する。
+- 2026-06-15: `.datarobot/cli/base.yml` は実際の infra が読む `DATABASE_CONNECTION_TYPE` を選択式にし、既存 use case を使う `DATAROBOT_DEFAULT_USE_CASE` を追加した。Snowflake / BigQuery / SAP の個別設定ブロックは維持する。
+- 2026-06-15: workflow と Pulumi optional resource の回帰として、`python-unit-tests.yml` が `app_backend/tests customize_docs` を実行すること、report builder flag / monitoring / cleanup job guard が消えていないことをテストで固定した。
+
 ### PR6: React frontend small changes
 
 目的: `v11.5.1` の React 側小差分を取り込み、custom UI を壊していないことを確認する。

--- a/infra/Taskfile.yaml
+++ b/infra/Taskfile.yaml
@@ -1,0 +1,118 @@
+---
+# https://taskfile.dev
+version: '3'
+
+tasks:
+  auth-check:
+    silent: true
+    desc: "🔐 Check authentication prerequisites"
+    cmds:
+      - |
+        if command -v dr >/dev/null 2>&1 && dr auth help 2>&1 | grep -q "check"; then
+          echo "🔐 Checking authentication.."
+          dr auth check
+        else
+          echo "ℹ️  Skipping auth check (not available)"
+        fi
+
+  pulumi-datarobot-plugin-check:
+    silent: true
+    cmds:
+      - |
+        if [ "${PULUMI_SKIP_UPDATE_CHECK:-0}" = "1" ]; then
+          uv run pulumi plugin install resource datarobot "${PULUMI_DATAROBOT_PLUGIN_VERSION:-v0.10.24}" \
+            --server "${PULUMI_DATAROBOT_DEFAULT_URL:-https://github.com/datarobot-community/pulumi-datarobot/releases/download/v0.10.24}"
+        fi
+
+  install:
+    desc: "🔧 Install infra dependencies"
+    dir: ..
+    cmds:
+      - uv sync --all-extras --dev
+
+  start:
+    silent: true
+    desc: "💻 Deploy backing infrastructure"
+    cmds:
+      - task: deploy-dev
+
+  lint:
+    silent: true
+    desc: "🧹 Run infra linters"
+    dir: ..
+    cmds:
+      - uv run ruff format infra
+      - uv run ruff check infra --fix
+
+  lint-check:
+    silent: true
+    desc: "🧹 Check infra lint"
+    dir: ..
+    cmds:
+      - uv run ruff format --check infra
+      - uv run ruff check infra
+
+  select:
+    silent: true
+    desc: "🚂 Select a Pulumi stack"
+    dir: ..
+    cmds:
+      - uv run pulumi stack select {{.CLI_ARGS}}
+
+  deploy:
+    silent: true
+    aliases: [up]
+    desc: "🔨 Deploy the infrastructure"
+    dir: ..
+    deps:
+      - auth-check
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - uv run pulumi up {{.CLI_ARGS}}
+
+  refresh:
+    silent: true
+    desc: "🔄 Refresh the infrastructure"
+    dir: ..
+    deps:
+      - auth-check
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - uv run pulumi refresh {{.CLI_ARGS}}
+
+  info:
+    silent: true
+    desc: "ℹ️ Show Pulumi stack info"
+    dir: ..
+    deps:
+      - auth-check
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - uv run pulumi stack {{.CLI_ARGS}}
+
+  down:
+    silent: true
+    aliases: [destroy]
+    desc: "💥 Destroy the deployed infrastructure"
+    dir: ..
+    deps:
+      - auth-check
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - uv run pulumi destroy {{.CLI_ARGS}}
+
+  deploy-dev:
+    silent: true
+    aliases: [up-dev]
+    desc: "🔨 Deploy development backing infrastructure"
+    dir: ..
+    deps:
+      - auth-check
+    cmds:
+      - task: pulumi-datarobot-plugin-check
+      - |
+        export PULUMI_SKIP_UPDATE_CHECK=1
+        uv run pulumi up -y \
+          --target "**[llm]" \
+          --target "**datarobot:index/useCase:UseCase**" \
+          {{.CLI_ARGS}}


### PR DESCRIPTION
## Summary
- add root `task deploy` / `task deploy-dev` entrypoints and include `infra/Taskfile.yaml`
- add infra Taskfile commands that keep the existing root `Pulumi.yaml` project instead of moving Pulumi into `infra/`
- align DataRobot CLI database setup with the runtime `DATABASE_CONNECTION_TYPE` env var and add `DATAROBOT_DEFAULT_USE_CASE`
- add regression tests for Taskfile DX, workflow test coverage, optional Pulumi resource guards, and PR5 implementation notes

## Notes
- This intentionally does not adopt the upstream `infra/Pulumi.yaml` and `infra/infra/*` relocation yet, because the current CD path still depends on the existing root Pulumi project and `infra/settings_*` modules.
- Polars-to-pandas migration remains out of scope.

## Validation
- `uv run pytest customize_docs/test_application_source_file_manifest.py customize_docs/test_pulumi_workflow_refresh.py customize_docs/test_custom_job_schedule_resource.py customize_docs/test_taskfile_deployment_dx.py -q`
- `uv run pytest app_backend/tests customize_docs -q`
- `uv run ruff check core/src/core infra app_backend/tests customize_docs`
- `uv run ruff format --check customize_docs/test_taskfile_deployment_dx.py customize_docs/test_pulumi_workflow_refresh.py customize_docs/test_custom_job_schedule_resource.py`
- `yamlfmt -conf .yamlfmt.yml -lint Taskfile.yaml infra/Taskfile.yaml .datarobot/cli/base.yml`
- `task --list --sort none`
