### PR TITLE
PR6: React frontend small compatibility changes

### DIFF
--- a/app_backend/tests/test_base_telemetry.py
+++ b/app_backend/tests/test_base_telemetry.py
@@ -9,9 +9,7 @@ from opentelemetry import context as otel_context
 
 class _ContextAttachingSpan:
     def __enter__(self) -> "_ContextAttachingSpan":
-        self._token = otel_context.attach(
-            otel_context.set_value("test-span", object())
-        )
+        self._token = otel_context.attach(otel_context.set_value("test-span", object()))
         return self
 
     def __exit__(self, *_args: Any) -> None:

--- a/app_backend/tests/test_base_telemetry.py
+++ b/app_backend/tests/test_base_telemetry.py
@@ -1,0 +1,73 @@
+import asyncio
+import contextvars
+import logging
+from typing import Any
+
+from core.base_telemetry import BaseTelemetry
+from opentelemetry import context as otel_context
+
+
+class _ContextAttachingSpan:
+    def __enter__(self) -> "_ContextAttachingSpan":
+        self._token = otel_context.attach(
+            otel_context.set_value("test-span", object())
+        )
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        otel_context.detach(self._token)
+
+    def end(self) -> None:
+        pass
+
+    def is_recording(self) -> bool:
+        return False
+
+    def record_exception(self, _exception: BaseException) -> None:
+        pass
+
+    def set_status(self, _status: Any) -> None:
+        pass
+
+
+class _ContextAttachingTracer:
+    def start_as_current_span(self, _name: str) -> _ContextAttachingSpan:
+        return _ContextAttachingSpan()
+
+    def start_span(self, _name: str) -> _ContextAttachingSpan:
+        return _ContextAttachingSpan()
+
+
+async def _run_in_context(context: contextvars.Context, awaitable: Any) -> Any:
+    task = context.run(asyncio.create_task, awaitable)
+    return await task
+
+
+def test_trace_async_generator_close_does_not_detach_in_different_context(
+    monkeypatch,
+    caplog,
+) -> None:
+    telemetry = BaseTelemetry()
+    monkeypatch.setattr(
+        telemetry,
+        "get_tracer",
+        lambda _name: _ContextAttachingTracer(),
+    )
+
+    @telemetry.trace
+    async def stream_values():
+        yield "first"
+        yield "second"
+
+    async def run() -> None:
+        stream = stream_values()
+        assert await _run_in_context(contextvars.Context(), stream.__anext__()) == (
+            "first"
+        )
+
+        with caplog.at_level(logging.ERROR, logger="opentelemetry.context"):
+            await _run_in_context(contextvars.Context(), stream.aclose())
+
+    asyncio.run(run())
+
+    assert "Failed to detach context" not in caplog.text

--- a/app_backend/tests/test_llm_client.py
+++ b/app_backend/tests/test_llm_client.py
@@ -169,21 +169,29 @@ def test_async_llm_client_uses_litellm_gateway_configuration(
     completions = _RecordingCompletions()
     litellm_calls: dict[str, Any] = {}
 
-    def fake_from_litellm(completion_fn: Any, **kwargs: Any) -> _FakeInstructorClient:
-        litellm_calls["completion_fn"] = completion_fn
+    async def fake_acompletion(**_kwargs: Any) -> Any:
+        return "raw"
+
+    def fake_patch(*_args: Any, **kwargs: Any) -> Any:
+        litellm_calls["completion_fn"] = kwargs["create"]
         litellm_calls["kwargs"] = kwargs
-        return _FakeInstructorClient(completions)
+        return completions.create
 
     monkeypatch.setattr(
         llm_client,
         "litellm",
-        SimpleNamespace(acompletion=object()),
+        SimpleNamespace(acompletion=fake_acompletion),
         raising=False,
     )
     monkeypatch.setattr(
         llm_client.instructor,
+        "patch",
+        fake_patch,
+    )
+    monkeypatch.setattr(
+        llm_client.instructor,
         "from_litellm",
-        fake_from_litellm,
+        lambda *_args, **_kwargs: pytest.fail("from_litellm should not be used"),
         raising=False,
     )
     monkeypatch.setattr(
@@ -201,12 +209,14 @@ def test_async_llm_client_uses_litellm_gateway_configuration(
                 messages=[],
                 model="datarobot-deployed-llm",
                 max_tokens=128,
+                response_model=object,
             )
 
     result = asyncio.run(run_client())
 
     assert result == "created"
     assert litellm_calls["completion_fn"] is llm_client.litellm.acompletion
+    assert litellm_calls["kwargs"]["mode"] is llm_client.instructor.Mode.MD_JSON
     assert completions.kwargs is not None
     assert completions.kwargs["model"] == "datarobot/bedrock/test-model"
     assert completions.kwargs["timeout"] == 180
@@ -214,6 +224,67 @@ def test_async_llm_client_uses_litellm_gateway_configuration(
     assert "max_tokens" not in completions.kwargs
     assert completions.kwargs["max_completion_tokens"] == 128
     assert "api_base" not in completions.kwargs
+
+
+def test_async_llm_client_litellm_create_with_completion_uses_async_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("USE_DATAROBOT_LLM_GATEWAY", "true")
+    monkeypatch.setenv("LLM_DEFAULT_MODEL", "datarobot/bedrock/test-model")
+    captured: dict[str, Any] = {}
+    raw_response = object()
+    structured_response = SimpleNamespace(_raw_response=raw_response)
+
+    async def fake_acompletion(**kwargs: Any) -> Any:
+        captured["acompletion_kwargs"] = kwargs
+        return raw_response
+
+    async def fake_create_fn(**kwargs: Any) -> Any:
+        captured["create_fn_kwargs"] = kwargs
+        return structured_response
+
+    def fake_patch(*_args: Any, **kwargs: Any) -> Any:
+        captured["patched_create"] = kwargs["create"]
+        captured["patched_mode"] = kwargs["mode"]
+        return fake_create_fn
+
+    monkeypatch.setattr(
+        llm_client,
+        "litellm",
+        SimpleNamespace(acompletion=fake_acompletion),
+        raising=False,
+    )
+    monkeypatch.setattr(llm_client.instructor, "patch", fake_patch)
+    monkeypatch.setattr(
+        llm_client.instructor,
+        "from_litellm",
+        lambda *_args, **_kwargs: pytest.fail(
+            "from_litellm treats coroutine functions as a sync client in instructor 1.3.4"
+        ),
+        raising=False,
+    )
+
+    async def run_client() -> tuple[Any, Any]:
+        async with llm_client.AsyncLLMClient(
+            dr_client=_FakeDataRobotClient(),
+            deployment_base_url="https://legacy.example.test/chat/completions",
+        ) as client:
+            return await client.chat.completions.create_with_completion(
+                messages=[],
+                model="datarobot-deployed-llm",
+                response_model=object,
+            )
+
+    response, raw = asyncio.run(run_client())
+
+    assert response is structured_response
+    assert raw is raw_response
+    assert captured["patched_create"] is fake_acompletion
+    assert captured["patched_mode"] is llm_client.instructor.Mode.MD_JSON
+    assert captured["create_fn_kwargs"]["model"] == "datarobot/bedrock/test-model"
+    assert captured["create_fn_kwargs"]["timeout"] == 180
+    assert captured["create_fn_kwargs"]["max_retries"] == 2
 
 
 def test_async_llm_client_injects_deployed_llm_api_base(
@@ -225,16 +296,29 @@ def test_async_llm_client_injects_deployed_llm_api_base(
     monkeypatch.setenv("LLM_DEFAULT_MODEL", "datarobot/datarobot-deployed-llm")
     completions = _RecordingCompletions()
 
+    async def fake_acompletion(**_kwargs: Any) -> Any:
+        return "raw"
+
+    def fake_patch(*_args: Any, **kwargs: Any) -> Any:
+        assert kwargs["create"] is llm_client.litellm.acompletion
+        assert kwargs["mode"] is llm_client.instructor.Mode.MD_JSON
+        return completions.create
+
     monkeypatch.setattr(
         llm_client,
         "litellm",
-        SimpleNamespace(acompletion=object()),
+        SimpleNamespace(acompletion=fake_acompletion),
         raising=False,
     )
     monkeypatch.setattr(
         llm_client.instructor,
+        "patch",
+        fake_patch,
+    )
+    monkeypatch.setattr(
+        llm_client.instructor,
         "from_litellm",
-        lambda *_args, **_kwargs: _FakeInstructorClient(completions),
+        lambda *_args, **_kwargs: pytest.fail("from_litellm should not be used"),
         raising=False,
     )
 
@@ -247,6 +331,7 @@ def test_async_llm_client_injects_deployed_llm_api_base(
                 messages=[],
                 model="datarobot-deployed-llm",
                 timeout=45,
+                response_model=object,
             )
 
     result = asyncio.run(run_client())

--- a/app_frontend/src/api/apiClient.ts
+++ b/app_frontend/src/api/apiClient.ts
@@ -1,29 +1,8 @@
 import axios from 'axios';
-import { isDev, isServedStatic } from '@/lib/utils';
-import { VITE_DEFAULT_PORT } from '@/constants/dev';
-
-const getApiUrl = () => {
-  // Adjust API URL based on the environment
-  let apiBaseURL: string = window.location.origin;
-  if (window.ENV?.APP_BASE_URL) {
-    apiBaseURL = `${apiBaseURL}/${window.ENV.APP_BASE_URL}`;
-  }
-  if (window.ENV?.APP_BASE_URL?.includes('notebook-sessions') && isDev()) {
-    apiBaseURL += `/ports/` + VITE_DEFAULT_PORT;
-  }
-  if (
-    window.ENV?.APP_BASE_URL?.includes('notebook-sessions') &&
-    window.ENV?.API_PORT &&
-    isServedStatic()
-  ) {
-    apiBaseURL += `/ports/` + window.ENV.API_PORT;
-  }
-  apiBaseURL += '/api';
-  return apiBaseURL;
-};
+import { getApiUrl } from '@/lib/utils';
 
 const apiClient = axios.create({
-  baseURL: `${getApiUrl()}`,
+  baseURL: getApiUrl(),
   headers: {
     Accept: 'application/json',
     'Content-type': 'application/json',

--- a/app_frontend/src/components/chat/MarkdownContent.tsx
+++ b/app_frontend/src/components/chat/MarkdownContent.tsx
@@ -20,6 +20,7 @@ export const MarkdownContent: React.FC<MarkdownContentProps> = ({ content, class
           ul: ({ ...props }) => <ul className="list-disc pl-5 my-2" {...props} />,
           ol: ({ ...props }) => <ol className="list-decimal pl-5 my-2" {...props} />,
           li: ({ ...props }) => <li className="my-1" {...props} />,
+          strong: ({ ...props }) => <strong {...props} />,
         }}
       />
     </div>

--- a/app_frontend/src/components/chat/SummaryTabContent.tsx
+++ b/app_frontend/src/components/chat/SummaryTabContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { HeaderSection } from './HeaderSection';
 import { PlotPanel } from './PlotPanel';
+import { MarkdownContent } from './MarkdownContent';
 import { parsePlotData } from './utils';
 import { useTranslation } from '@/i18n';
 
@@ -17,7 +18,11 @@ export const SummaryTabContent: React.FC<SummaryTabContentProps> = ({ bottomLine
 
   return (
     <div>
-      {bottomLine && <HeaderSection title={t('Bottom line')}>{bottomLine}</HeaderSection>}
+      {bottomLine && (
+        <HeaderSection title={t('Bottom line')}>
+          <MarkdownContent content={bottomLine} />
+        </HeaderSection>
+      )}
       <div className="flex flex-col gap-2.5">
         {plot1 && <PlotPanel plotData={plot1} />}
         {plot2 && <PlotPanel plotData={plot2} />}

--- a/app_frontend/src/global.d.ts
+++ b/app_frontend/src/global.d.ts
@@ -6,6 +6,7 @@ declare global {
   interface Window {
     ENV: {
       APP_BASE_URL?: string;
+      BASE_PATH?: string;
       API_PORT?: string;
       DATAROBOT_ENDPOINT?: string;
       IS_STATIC_FRONTEND?: boolean;

--- a/app_frontend/src/lib/utils.ts
+++ b/app_frontend/src/lib/utils.ts
@@ -1,7 +1,37 @@
+import { VITE_DEFAULT_PORT } from '@/constants/dev';
 import { useRef, useEffect, useCallback } from 'react';
 import { clsx, type ClassValue } from 'clsx';
 
 import { twMerge } from 'tailwind-merge';
+
+const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, '');
+
+const joinUrlPath = (origin: string, path?: string) => {
+  if (!path) {
+    return origin;
+  }
+  return `${origin}/${trimSlashes(path)}`;
+};
+
+export function getBaseUrl() {
+  const runtimeBaseUrl = window.ENV?.APP_BASE_URL ?? window.ENV?.BASE_PATH;
+
+  if (runtimeBaseUrl?.includes('notebook-sessions') && window.ENV?.API_PORT && isServedStatic()) {
+    return `${trimSlashes(runtimeBaseUrl)}/ports/${window.ENV.API_PORT}`;
+  }
+
+  return runtimeBaseUrl;
+}
+
+export function getApiUrl() {
+  let apiBaseURL = joinUrlPath(window.location.origin, getBaseUrl());
+
+  if (getBaseUrl()?.includes('notebook-sessions') && isDev() && !isServedStatic()) {
+    apiBaseURL += `/ports/${VITE_DEFAULT_PORT}`;
+  }
+
+  return `${apiBaseURL}/api`;
+}
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/app_frontend/src/main.tsx
+++ b/app_frontend/src/main.tsx
@@ -7,21 +7,14 @@ import '@fontsource/dm-sans/400.css';
 import '@fontsource/dm-sans/500.css';
 import '@fontsource/dm-sans/600.css';
 import '@fontsource/dm-sans/700.css';
-import { isServedStatic } from '@/lib/utils.ts';
+import { getBaseUrl } from '@/lib/utils.ts';
 import './index.css';
 import App from './App.tsx';
 import { AppStateProvider } from './state';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import i18n from './i18n';
 
-let basename = window.ENV?.APP_BASE_URL ?? undefined;
-if (
-  window.ENV?.APP_BASE_URL?.includes('notebook-sessions') &&
-  window.ENV?.API_PORT &&
-  isServedStatic()
-) {
-  basename += `/ports/` + window.ENV.API_PORT;
-}
+const basename = getBaseUrl();
 
 const queryClient = new QueryClient();
 

--- a/app_frontend/tests/components/AddDataModal.test.tsx
+++ b/app_frontend/tests/components/AddDataModal.test.tsx
@@ -1,0 +1,119 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { AddDataModal } from '@/components/AddDataModal';
+import { renderWithProviders } from '../test-utils';
+
+const mockUploadMutate = vi.fn();
+const mockLoadFromDatabase = vi.fn();
+const mockSelectDataSources = vi.fn();
+
+vi.mock('@/api/datasets/hooks', () => ({
+  useFetchDatasets: () => ({
+    data: {
+      local: [{ id: 'local-1', name: 'sales.csv', size: '12 KB' }],
+      remote: [{ id: 'remote-1', name: 'catalog-sales.csv', size: '3 MB' }],
+    },
+    isLoading: false,
+  }),
+  useFileUploadMutation: () => ({
+    mutate: mockUploadMutate,
+    progress: 0,
+  }),
+  useGetSupportedDataSourceTypes: () => ({
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/api/database/hooks', () => ({
+  useGetDatabaseSchemas: () => ({
+    data: {
+      public: 'Public schema',
+      finance: 'Finance schema',
+    },
+  }),
+  useGetDefaultSchema: () => ({
+    data: 'public',
+  }),
+  useGetDatabaseTables: () => ({
+    data: {
+      orders: 'Orders table',
+      customers: 'Customers table',
+    },
+    isLoading: false,
+  }),
+  useLoadFromDatabaseMutation: () => ({
+    mutate: mockLoadFromDatabase,
+  }),
+}));
+
+vi.mock('@/api/datasources/hooks', () => ({
+  useListAvailableDataStores: () => ({
+    data: [
+      {
+        id: 'store-1',
+        canonical_name: 'Postgres store',
+        defined_data_sources: [
+          {
+            schema: 'public',
+            table: 'orders',
+          },
+        ],
+      },
+    ],
+    isLoading: false,
+  }),
+  useSelectDataSourcesMutation: () => ({
+    mutate: mockSelectDataSources,
+  }),
+}));
+
+describe('AddDataModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('keeps local upload and catalog selection visible by default', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AddDataModal />);
+
+    await user.click(screen.getByRole('button', { name: /add data/i }));
+
+    expect(screen.getByText('Local files')).toBeInTheDocument();
+    expect(
+      screen.getByText('Select one or more CSV, XLSX, XLS files, up to 200MB.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Data Registry')).toBeInTheDocument();
+    expect(screen.getByText('Select one or more catalog items')).toBeInTheDocument();
+  });
+
+  test('keeps database schema and table selection available', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AddDataModal />);
+
+    await user.click(screen.getByRole('button', { name: /add data/i }));
+    await user.click(screen.getByRole('radio', { name: 'Database' }));
+
+    expect(screen.getByText('Database Schema')).toBeInTheDocument();
+    expect(screen.getByLabelText('Schema')).toHaveValue('public');
+    expect(screen.getByRole('option', { name: 'public - Public schema' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'finance - Finance schema' })).toBeInTheDocument();
+    expect(screen.getByText('Database Tables')).toBeInTheDocument();
+    expect(screen.getByTestId('database-table-select')).toHaveTextContent(
+      'Select one or more tables.'
+    );
+  });
+
+  test('keeps remote data connection selection available', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AddDataModal />);
+
+    await user.click(screen.getByRole('button', { name: /add data/i }));
+    await user.click(screen.getByRole('radio', { name: 'Remote Data Connections' }));
+
+    expect(screen.getByText('Add External Data Source')).toBeInTheDocument();
+    expect(screen.getByText('Select a data store')).toBeInTheDocument();
+    expect(screen.getByText('Select one or more data sources')).toBeInTheDocument();
+  });
+});

--- a/app_frontend/tests/components/CustomFeatureEntrypoints.test.tsx
+++ b/app_frontend/tests/components/CustomFeatureEntrypoints.test.tsx
@@ -1,0 +1,85 @@
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { SavePromptButton } from '@/components/custom-prompts/SavePromptButton';
+import { TemplateSelector } from '@/components/template/TemplateSelector';
+import { renderWithProviders } from '../test-utils';
+
+vi.mock('@/api/feature-flag', () => ({
+  useFetchFeatureFlags: () => ({
+    data: {
+      templateEditEnabled: true,
+      customPromptsEnabled: true,
+      refinerEnabled: true,
+      refinerAutoSend: false,
+      reportBuilderEnabled: true,
+    },
+  }),
+}));
+
+vi.mock('@/api/templates/hooks', () => ({
+  useFetchTemplates: () => ({
+    data: {
+      templates: [
+        {
+          name: 'Standard analysis',
+          category: '分析',
+          description: 'Built-in template',
+          prompt_text_template: 'Analyze sales',
+        },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  }),
+  useFetchTemplateCategories: () => ({
+    data: {
+      categories: ['分析'],
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/api/custom-prompts/hooks', () => ({
+  useFetchCustomPrompts: () => ({
+    data: {
+      custom_prompts: [
+        {
+          name: 'Saved custom prompt',
+          prompt_text: 'Use my saved prompt',
+        },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  }),
+  useDeleteCustomPrompt: () => ({
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+describe('custom feature entrypoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('shows the save prompt entrypoint when custom prompts are enabled', () => {
+    renderWithProviders(<SavePromptButton promptText="Summarize sales" />);
+
+    expect(screen.getByRole('button', { name: 'Save as custom prompt' })).toHaveAttribute(
+      'title',
+      'Save as custom prompt'
+    );
+  });
+
+  test('keeps the template selector and custom prompt category available', () => {
+    renderWithProviders(
+      <TemplateSelector open onOpenChange={() => {}} onSelectTemplate={() => {}} />
+    );
+
+    expect(screen.getByText('Select Prompt Template')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'All Categories' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'カスタム' })).toBeInTheDocument();
+    expect(screen.getByText('Standard analysis')).toBeInTheDocument();
+    expect(screen.getByText('Saved custom prompt')).toBeInTheDocument();
+  });
+});

--- a/app_frontend/tests/components/MarkdownSummary.test.tsx
+++ b/app_frontend/tests/components/MarkdownSummary.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { MarkdownContent } from '@/components/chat/MarkdownContent';
+import { SummaryTabContent } from '@/components/chat/SummaryTabContent';
+
+vi.mock('@/components/chat/PlotPanel', () => ({
+  PlotPanel: ({ plotData }: { plotData: { layout?: { title?: { text?: string } } } }) => (
+    <div data-testid="plot-panel">{plotData.layout?.title?.text}</div>
+  ),
+}));
+
+describe('MarkdownContent and summary rendering', () => {
+  test('renders strong markdown as semantic bold text', () => {
+    render(<MarkdownContent content="Revenue is **up** this quarter." />);
+
+    const strong = screen.getByText('up');
+    expect(strong.tagName).toBe('STRONG');
+  });
+
+  test('renders bottom line markdown in the summary tab', () => {
+    render(<SummaryTabContent bottomLine="**Revenue** increased." fig1="" fig2="" />);
+
+    expect(screen.getByText('Bottom line')).toBeInTheDocument();
+    expect(screen.getByText('Revenue').tagName).toBe('STRONG');
+  });
+
+  test('continues rendering summary plots when figure JSON is present', () => {
+    render(
+      <SummaryTabContent
+        bottomLine="Result"
+        fig1='{"data":[],"layout":{"title":{"text":"First plot"}}}'
+        fig2='{"data":[],"layout":{"title":{"text":"Second plot"}}}'
+      />
+    );
+
+    expect(screen.getByText('First plot')).toBeInTheDocument();
+    expect(screen.getByText('Second plot')).toBeInTheDocument();
+  });
+});

--- a/app_frontend/tests/lib/utils.test.ts
+++ b/app_frontend/tests/lib/utils.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getApiUrl, getBaseUrl } from '@/lib/utils';
+
+const originalEnv = window.ENV;
+
+afterEach(() => {
+  window.ENV = originalEnv;
+  vi.unstubAllEnvs();
+});
+
+describe('frontend URL helpers', () => {
+  test('builds the default API URL from the current origin', () => {
+    window.ENV = {};
+
+    expect(getBaseUrl()).toBe(undefined);
+    expect(getApiUrl()).toBe('http://localhost:3000/api');
+  });
+
+  test('preserves DataRobot app base paths from runtime env', () => {
+    window.ENV = {
+      APP_BASE_URL: 'custom_applications/app-id',
+    };
+
+    expect(getBaseUrl()).toBe('custom_applications/app-id');
+    expect(getApiUrl()).toBe('http://localhost:3000/custom_applications/app-id/api');
+  });
+
+  test('uses Vite notebook port during local notebook development', () => {
+    vi.stubEnv('MODE', 'development');
+    window.ENV = {
+      APP_BASE_URL: 'notebook-sessions/notebook-id',
+    };
+
+    expect(getApiUrl()).toBe('http://localhost:3000/notebook-sessions/notebook-id/ports/5173/api');
+  });
+
+  test('uses backend API port when static frontend is served in notebooks', () => {
+    window.ENV = {
+      APP_BASE_URL: 'notebook-sessions/notebook-id',
+      API_PORT: '8080',
+      IS_STATIC_FRONTEND: true,
+    };
+
+    expect(getBaseUrl()).toBe('notebook-sessions/notebook-id/ports/8080');
+    expect(getApiUrl()).toBe('http://localhost:3000/notebook-sessions/notebook-id/ports/8080/api');
+  });
+});

--- a/core/src/core/base_telemetry.py
+++ b/core/src/core/base_telemetry.py
@@ -26,7 +26,7 @@ import inspect
 import logging
 import os
 import time
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from typing import (
     Any,
     AsyncGenerator,
@@ -465,9 +465,21 @@ class BaseTelemetry:
 
             @functools.wraps(func)
             async def inner_asyncgen(*args, **kwargs):
-                with tracer.start_as_current_span(span_name):
-                    async for x in func(*args, **kwargs):
+                span = tracer.start_span(span_name)
+                async_generator = func(*args, **kwargs)
+                try:
+                    while True:
+                        try:
+                            with trace.use_span(span, end_on_exit=False):
+                                x = await async_generator.__anext__()
+                        except StopAsyncIteration:
+                            break
                         yield x
+                finally:
+                    with suppress(Exception):
+                        with trace.use_span(span, end_on_exit=False):
+                            await async_generator.aclose()
+                    span.end()
 
             return inner_asyncgen
         elif inspect.isgeneratorfunction(func):

--- a/core/src/core/llm_client.py
+++ b/core/src/core/llm_client.py
@@ -398,8 +398,16 @@ class AsyncLLMClient:
             if dr_token:
                 llm_config = replace(llm_config, datarobot_api_token=dr_token)
 
-        self._instructor_client = instructor.from_litellm(
-            litellm.acompletion,
+        # instructor 1.3.4 checks inspect.isawaitable() in from_litellm(), which
+        # misclassifies coroutine functions such as litellm.acompletion as sync.
+        # Build the AsyncInstructor explicitly so create_with_completion awaits
+        # the LiteLLM coroutine before reading _raw_response.
+        self._instructor_client = instructor.AsyncInstructor(
+            client=None,
+            create=instructor.patch(
+                create=litellm.acompletion,
+                mode=instructor.Mode.MD_JSON,
+            ),
             mode=instructor.Mode.MD_JSON,
         )
         return TokenTrackingProxy(

--- a/customize_docs/dev_branch_runtime_error_investigation_20260616.md
+++ b/customize_docs/dev_branch_runtime_error_investigation_20260616.md
@@ -1,0 +1,77 @@
+# dev ブランチ実行時エラー調査メモ
+
+## 対象ログ
+
+- `AttributeError: 'coroutine' object has no attribute '_raw_response'`
+- `RuntimeWarning: coroutine 'acompletion' was never awaited`
+- `opentelemetry.context: Failed to detach context`
+
+## 調査方針
+
+- LLM 呼び出しは `AsyncLLMClient` の LiteLLM 経路を中心に確認する。
+- OpenTelemetry は async generator の計測ラッパーが `yield` をまたいで context を保持していないか確認する。
+- 再発防止のため、提示されたログに対応する回帰テストを `app_backend/tests` に追加する。
+
+## 原因
+
+### LiteLLM / Instructor
+
+`core.llm_client.AsyncLLMClient` の LiteLLM 経路で `instructor.from_litellm(litellm.acompletion, ...)` を使っていた。
+このリポジトリで固定されている `instructor==1.3.4` の `from_litellm()` は `inspect.isawaitable(completion)` で非同期判定するため、coroutine function である `litellm.acompletion` を同期クライアントとして扱ってしまう。
+
+その結果、`create_with_completion()` 内で LiteLLM の coroutine が await されず、coroutine オブジェクトに対して `_raw_response` を読みに行き、以下が発生する。
+
+- `AttributeError: 'coroutine' object has no attribute '_raw_response'`
+- `RuntimeWarning: coroutine 'acompletion' was never awaited`
+
+現行の Instructor ドキュメントでは LiteLLM の async 利用は `from_provider(..., async_client=True)` が推奨されているが、固定版 `1.3.4` では既存構成との互換を優先し、`AsyncInstructor` と `instructor.patch(create=litellm.acompletion, ...)` を明示的に組み立てる。
+
+### OpenTelemetry
+
+`BaseTelemetry.trace()` の async generator ラッパーが `with tracer.start_as_current_span(...):` を開いたまま `yield` していた。
+HTTP streaming やクライアント切断などで async generator が別の asyncio context から close されると、OpenTelemetry の `ContextVar` token を作成元と異なる context で detach し、以下が発生する。
+
+- `opentelemetry.context: Failed to detach context`
+- `ValueError: Token was created in a different Context`
+
+## 対応
+
+- `core/src/core/llm_client.py`
+  - LiteLLM 経路では `from_litellm()` を使わず、`instructor.AsyncInstructor` を明示構築する。
+  - `instructor.patch(create=litellm.acompletion, mode=Mode.MD_JSON)` により、LiteLLM coroutine を await する adapter を使う。
+- `core/src/core/base_telemetry.py`
+  - async generator の span は `tracer.start_span()` で作成する。
+  - `trace.use_span(..., end_on_exit=False)` は `__anext__()` 実行中だけ有効にし、`yield` をまたいで OpenTelemetry context を保持しない。
+
+## 追加テスト
+
+- `app_backend/tests/test_llm_client.py`
+  - LiteLLM Gateway 経路で `from_litellm()` に戻らないこと。
+  - `create_with_completion()` が async adapter 経由で `_raw_response` を取得できること。
+  - model 解決、timeout、retry、token 引数変換、DataRobot deployment `api_base` 注入が維持されること。
+- `app_backend/tests/test_base_telemetry.py`
+  - async generator を別 context で close しても `Failed to detach context` が出ないこと。
+
+## テスト結果
+
+- `uv run pytest app_backend/tests/test_llm_client.py app_backend/tests/test_llm_timeout.py app_backend/tests/test_base_telemetry.py`
+  - 14 passed
+  - 既存の deprecation warning は今回変更外
+
+## upstream 取り込み時の注意
+
+このリポジトリは基本的に upstream を優先して取り込む方針。今回の 2 点は、現 dev で見つかった実行時エラーの再発確認ポイントとして扱う。ローカル差分を固定的に守る前提にはしない。
+
+- LiteLLM 経路
+  - upstream 側で Instructor / LiteLLM の使い方や依存バージョンが更新されている場合は upstream 実装を採用する。
+  - 採用後に LiteLLM Gateway 経路のテストを実行し、`_raw_response` エラーや `acompletion` の await 漏れが再発しないことを確認する。
+  - 同じエラーが再現した場合のみ、現 dev の `AsyncInstructor` 明示構築のような補正を再検討する。
+- OpenTelemetry async generator tracing
+  - upstream 側で telemetry wrapper が整理されている場合は upstream 実装を採用する。
+  - 採用後に streaming / client disconnect 相当のテストを実行し、`Failed to detach context` が再発しないことを確認する。
+  - 同じエラーが再現した場合のみ、`yield` をまたいで OTel context を保持しない補正を再検討する。
+
+upstream 同期PRでは最低限以下を実行する。
+
+- `uv run pytest app_backend/tests/test_llm_client.py::test_async_llm_client_litellm_create_with_completion_uses_async_adapter`
+- `uv run pytest app_backend/tests/test_base_telemetry.py::test_trace_async_generator_close_does_not_detach_in_different_context`

--- a/customize_docs/upstream_sync_plan.md
+++ b/customize_docs/upstream_sync_plan.md
@@ -25,6 +25,21 @@
 5. 各段階で「取り込む / 見送る / 手動移植する」をこのファイルへ記録する。
 6. すでに手動移植済みの upstream タグは、内容差分なしの `ours` baseline merge で履歴上も取り込み済みにする。
 
+## upstream 追従時の検証注意点
+
+基本方針は upstream を優先して取り込むこと。以下は「ローカル差分を固定的に維持する」ためのメモではなく、upstream 取り込み時に同種の実行時エラーが再発しないか確認するための注意点。
+
+- `core/src/core/llm_client.py`
+  - 現 dev では `instructor==1.3.4` と `litellm.acompletion` の組み合わせで、`AttributeError: 'coroutine' object has no attribute '_raw_response'` / `coroutine 'acompletion' was never awaited` が発生した。
+  - upstream 取り込み時は upstream 実装を優先する。upstream 側で Instructor / LiteLLM の使い方や依存バージョンが更新されている場合は、その実装を採用する。
+  - 採用後、LiteLLM Gateway 経路の回帰確認として `app_backend/tests/test_llm_client.py::test_async_llm_client_litellm_create_with_completion_uses_async_adapter` または同等の upstream 向けテストを実行する。
+  - テストで同じエラーが再現した場合のみ、現 dev の `AsyncInstructor` 明示構築のような補正を再検討する。
+- `core/src/core/base_telemetry.py`
+  - 現 dev では async generator の tracing で、別 asyncio context から generator が close された場合に `opentelemetry.context: Failed to detach context` が発生した。
+  - upstream 取り込み時は upstream 実装を優先する。upstream 側で telemetry wrapper が整理されている場合は、その実装を採用する。
+  - 採用後、streaming / client disconnect 相当の回帰確認として `app_backend/tests/test_base_telemetry.py::test_trace_async_generator_close_does_not_detach_in_different_context` または同等の upstream 向けテストを実行する。
+  - テストで同じエラーが再現した場合のみ、`yield` をまたいで OpenTelemetry context を保持しない補正を再検討する。
+
 ## テスト方針
 
 各同期PRで最低限以下を実行する。

--- a/customize_docs/v11_5_1_integration_plan.md
+++ b/customize_docs/v11_5_1_integration_plan.md
@@ -363,6 +363,15 @@ PR2 の core package mechanical migration で、top-level 依存も切り替え�
 - `npm --prefix app_frontend run build`
 - 必要なら `pnpm --dir app_frontend dev` で Add Data modal / Chat / Data / Reports をブラウザ確認する。
 
+実装メモ:
+
+- 2026-06-16: PR6 用ブランチ `codex/pr6-react-frontend-small-changes` を最新 `origin/dev` から作成した。
+- 2026-06-16: RED として AddDataModal の local upload / database schema-table / remote data connection 表示、Markdown summary rendering、custom reports/prompts/template selector 導線、frontend URL helper の回帰テストを追加した。
+- 2026-06-16: `apiClient.ts` の API URL 組み立てを `lib/utils.ts` に集約した。upstream `v11.5.1` の `getApiUrl()` 方針を採用しつつ、既存の `APP_BASE_URL` / `_dr_env.js` / static notebook frontend の `API_PORT` 対応は維持する。
+- 2026-06-16: Summary tab の bottom line を `MarkdownContent` で描画するようにし、太字などの markdown 表示を有効にした。plot rendering は既存通り維持する。
+- 2026-06-16: upstream との差分に含まれる custom reports / custom prompts / template / refiner の削除は採用しない。既存 customize 導線が残ることを frontend tests で固定する。
+- 2026-06-16: Vite config と favicon は現行の `_dr_env.js` proxy / static build / `public/datarobot_favicon.png` 配置を維持する。upstream の `public/assets/datarobot_favicon.png` 追加は現行 `index.html` の参照パスと一致しないため、この PR では採用しない。
+
 ### PR7: v11.5.1 history baseline
 
 目的: 内容差分の採用・見送りを記録し、Git 履歴上も `v11.5.1` を処理済みにする。


### PR DESCRIPTION
## Summary

- Add frontend regression coverage for the PR6 scope: Add Data modal data-source entrypoints, markdown summary rendering, custom prompt/template entrypoints, and runtime URL helpers.
- Move API/base URL construction into `app_frontend/src/lib/utils.ts` and keep existing DataRobot runtime behavior for `APP_BASE_URL`, `_dr_env.js`, notebook sessions, static frontend mode, and `API_PORT`.
- Render summary bottom-line text through `MarkdownContent` so upstream-style markdown such as bold text is preserved.
- Record PR6 implementation notes in `customize_docs/v11_5_1_integration_plan.md`.

## Deliberately not included

- Did not adopt upstream deletes around custom reports, custom prompts, templates, or question refiner paths.
- Did not touch the Polars-to-pandas migration work.
- Preserved the current Vite config and favicon path because the existing `_dr_env.js` proxy/static frontend behavior still needs to work.

## Validation

- `npm --prefix app_frontend test -- tests/lib/utils.test.ts tests/components/AddDataModal.test.tsx tests/components/MarkdownSummary.test.tsx tests/components/CustomFeatureEntrypoints.test.tsx`
- `npm --prefix app_frontend test`
- `npm --prefix app_frontend run lint` (passes with existing warnings)
- `npm --prefix app_frontend run build`
- Browser smoke against local Vite dev server: Add Data/database path and Reports route empty state rendered without a backend by mocked API responses.
