### PR TITLE
[codex] Align deployed LLM model configuration with upstream

### DIFF
--- a/app_backend/tests/test_llm_client.py
+++ b/app_backend/tests/test_llm_client.py
@@ -354,6 +354,52 @@ def test_async_llm_client_injects_deployed_llm_api_base(
     assert completions.kwargs["timeout"] == 45
 
 
+def test_async_llm_client_deployed_llm_uses_provider_when_default_model_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://app.datarobot.example/api/v2")
+    monkeypatch.setenv("TEXTGEN_DEPLOYMENT_ID", "deployment-123")
+    completions = _RecordingCompletions()
+
+    async def fake_acompletion(**_kwargs: Any) -> Any:
+        return "raw"
+
+    def fake_patch(*_args: Any, **kwargs: Any) -> Any:
+        assert kwargs["create"] is llm_client.litellm.acompletion
+        assert kwargs["mode"] is llm_client.instructor.Mode.MD_JSON
+        return completions.create
+
+    monkeypatch.setattr(
+        llm_client,
+        "litellm",
+        SimpleNamespace(acompletion=fake_acompletion),
+        raising=False,
+    )
+    monkeypatch.setattr(llm_client.instructor, "patch", fake_patch)
+
+    async def run_client() -> str:
+        async with AsyncLLMClient(
+            dr_client=_FakeDataRobotClient(),
+            deployment_base_url="https://legacy.example.test/chat/completions",
+        ) as client:
+            return await client.chat.completions.create(
+                messages=[],
+                model="datarobot-deployed-llm",
+                response_model=object,
+            )
+
+    result = asyncio.run(run_client())
+
+    assert result == "created"
+    assert completions.kwargs is not None
+    assert completions.kwargs["api_base"] == (
+        "https://app.datarobot.example/api/v2/deployments/"
+        "deployment-123/chat/completions"
+    )
+    assert completions.kwargs["model"] == "datarobot/datarobot-deployed-llm"
+
+
 def test_async_llm_client_deployed_llm_create_round_trips_to_deployment_endpoint() -> (
     None
 ):

--- a/app_backend/tests/test_llm_model_constants.py
+++ b/app_backend/tests/test_llm_model_constants.py
@@ -1,0 +1,27 @@
+from core import constants
+
+
+def test_get_llm_model_adds_datarobot_provider_prefix() -> None:
+    assert (
+        constants.get_llm_model("datarobot-deployed-llm")
+        == "datarobot/datarobot-deployed-llm"
+    )
+    assert (
+        constants.get_llm_model("bedrock/anthropic.claude-test")
+        == "datarobot/bedrock/anthropic.claude-test"
+    )
+
+
+def test_get_llm_model_preserves_existing_datarobot_provider_prefix() -> None:
+    assert (
+        constants.get_llm_model("datarobot/bedrock/anthropic.claude-test")
+        == "datarobot/bedrock/anthropic.claude-test"
+    )
+
+
+def test_get_llm_model_uses_llm_default_model_env(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("LLM_DEFAULT_MODEL", "bedrock/anthropic.claude-test")
+
+    assert constants.get_llm_model() == "datarobot/bedrock/anthropic.claude-test"

--- a/core/src/core/constants.py
+++ b/core/src/core/constants.py
@@ -11,11 +11,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from typing import Final
 
+DEFAULT_DEPLOYED_LLM_MODEL = "datarobot-deployed-llm"
+
+
+def _normalize_model_name(raw_model: str) -> str:
+    """Add the DataRobot provider prefix expected by LiteLLM."""
+    if raw_model.startswith("datarobot/"):
+        return raw_model
+    return f"datarobot/{raw_model}"
+
+
+def get_llm_model(preferred_model: str | None = None) -> str:
+    """Return the runtime LLM model name using upstream provider-prefix rules."""
+    raw_model = (
+        preferred_model
+        or os.environ.get("LLM_DEFAULT_MODEL")
+        or DEFAULT_DEPLOYED_LLM_MODEL
+    )
+    return _normalize_model_name(raw_model)
+
 # LLM Model Configuration
-ALTERNATIVE_LLM_BIG = "datarobot-deployed-llm"
-ALTERNATIVE_LLM_SMALL = "datarobot-deployed-llm"
+ALTERNATIVE_LLM_BIG = get_llm_model()
+ALTERNATIVE_LLM_SMALL = get_llm_model()
 DEFAULT_LLM_GATEWAY_MODEL = "azure/gpt-4o"
 DEFAULT_LLM_GATEWAY_MODEL_SMALL = "azure/gpt-4o-mini"
 

--- a/core/src/core/constants.py
+++ b/core/src/core/constants.py
@@ -33,6 +33,7 @@ def get_llm_model(preferred_model: str | None = None) -> str:
     )
     return _normalize_model_name(raw_model)
 
+
 # LLM Model Configuration
 ALTERNATIVE_LLM_BIG = get_llm_model()
 ALTERNATIVE_LLM_SMALL = get_llm_model()

--- a/core/src/core/llm_client.py
+++ b/core/src/core/llm_client.py
@@ -23,6 +23,7 @@ from typing import Any, Type
 import instructor
 from openai import AsyncOpenAI
 
+from core.constants import get_llm_model
 from core.token_tracking import TokenUsageTracker
 
 try:
@@ -144,15 +145,24 @@ class LLMClientConfig:
     def resolve_model(self, requested_model: str | None) -> str | None:
         """Map generic model aliases to the configured runtime model."""
         if requested_model is None:
-            return self.default_model
+            if self.default_model:
+                return get_llm_model(self.default_model)
+            if self.deployment_api_base:
+                return get_llm_model()
+            return None
         if self.default_model and requested_model in _MODEL_ALIASES_FOR_CONFIG_DEFAULT:
-            return self.default_model
+            return get_llm_model(self.default_model)
+        if (
+            self.deployment_api_base
+            and requested_model in _MODEL_ALIASES_FOR_CONFIG_DEFAULT
+        ):
+            return get_llm_model(requested_model)
         if (
             self.use_datarobot_llm_gateway
             and "/" not in requested_model
             and requested_model
         ):
-            return f"datarobot/{requested_model}"
+            return get_llm_model(requested_model)
         return requested_model
 
 

--- a/customize_docs/dev_branch_runtime_error_investigation_20260616.md
+++ b/customize_docs/dev_branch_runtime_error_investigation_20260616.md
@@ -5,6 +5,7 @@
 - `AttributeError: 'coroutine' object has no attribute '_raw_response'`
 - `RuntimeWarning: coroutine 'acompletion' was never awaited`
 - `opentelemetry.context: Failed to detach context`
+- `litellm.BadRequestError: LLM Provider NOT provided`
 
 ## 調査方針
 
@@ -26,6 +27,14 @@
 
 現行の Instructor ドキュメントでは LiteLLM の async 利用は `from_provider(..., async_client=True)` が推奨されているが、固定版 `1.3.4` では既存構成との互換を優先し、`AsyncInstructor` と `instructor.patch(create=litellm.acompletion, ...)` を明示的に組み立てる。
 
+### DataRobot deployed LLM model name
+
+upstream v11.5.1 / v11.8.2 は `LLM_DEFAULT_MODEL` を app runtime parameter に渡し、`core.constants.get_llm_model()` で `datarobot/` provider prefix を補完する。
+fork 側の旧 `infra/__main__.py` では app runtime parameter に `LLM_DEFAULT_MODEL` が含まれていなかったため、`TEXTGEN_DEPLOYMENT_ID` / `LLM_DEPLOYMENT_ID` のみがある環境では generic alias の `datarobot-deployed-llm` が LiteLLM にそのまま渡る可能性があった。
+LiteLLM の DataRobot provider は provider prefix 付き model 名を routing に使うため、`model=datarobot-deployed-llm` のままだと以下が発生する。
+
+- `litellm.BadRequestError: LLM Provider NOT provided`
+
 ### OpenTelemetry
 
 `BaseTelemetry.trace()` の async generator ラッパーが `with tracer.start_as_current_span(...):` を開いたまま `yield` していた。
@@ -40,6 +49,11 @@ HTTP streaming やクライアント切断などで async generator が別の as
   - LiteLLM 経路では `from_litellm()` を使わず、`instructor.AsyncInstructor` を明示構築する。
   - `instructor.patch(create=litellm.acompletion, mode=Mode.MD_JSON)` により、LiteLLM coroutine を await する adapter を使う。
   - LiteLLM 経路の `AsyncLLMClient.__aexit__()` で `close_litellm_async_clients()` を await し、DataRobot deployment 呼び出し後の async HTTP client cleanup warning を防ぐ。
+  - `LLM_DEFAULT_MODEL` が未設定の既存環境でも DataRobot deployment alias を `datarobot/datarobot-deployed-llm` に解決する。
+- `core/src/core/constants.py`
+  - upstream と同様に `get_llm_model()` を追加し、`LLM_DEFAULT_MODEL` または既定 alias に `datarobot/` provider prefix を補完する。
+- `infra/__main__.py`
+  - 旧 infra 構成でも app runtime parameter に `LLM_DEFAULT_MODEL` を渡す。
 - `core/src/core/base_telemetry.py`
   - async generator の span は `tracer.start_span()` で作成する。
   - `trace.use_span(..., end_on_exit=False)` は `__anext__()` 実行中だけ有効にし、`yield` をまたいで OpenTelemetry context を保持しない。
@@ -53,7 +67,12 @@ HTTP streaming やクライアント切断などで async generator が別の as
   - LiteLLM Gateway 経路で `from_litellm()` に戻らないこと。
   - `create_with_completion()` が async adapter 経由で `_raw_response` を取得できること。
   - model 解決、timeout、retry、token 引数変換、DataRobot deployment `api_base` 注入が維持されること。
+  - `LLM_DEFAULT_MODEL` 未設定でも deployed LLM alias が provider prefix 付きに正規化されること。
   - ローカルの OpenAI 互換 HTTP server を DataRobot deployment に見立て、`AsyncLLMClient` が `/api/v2/deployments/{id}/chat/completions/` に bearer token 付きで POST し、structured response を返せること。
+- `app_backend/tests/test_llm_model_constants.py`
+  - `get_llm_model()` が upstream と同じ `datarobot/` provider prefix 補完を行うこと。
+- `customize_docs/test_llm_runtime_parameters.py`
+  - `infra/__main__.py` の app runtime parameter に `LLM_DEFAULT_MODEL` が含まれること。
 - `app_backend/tests/test_base_telemetry.py`
   - async generator を別 context で close しても `Failed to detach context` が出ないこと。
 - `app_backend/tests/test_api_analysis_execution_v0424_compat.py`
@@ -71,6 +90,11 @@ HTTP streaming やクライアント切断などで async generator が別の as
 - `uv run pytest app_backend/tests/test_llm_client.py app_backend/tests/test_llm_timeout.py app_backend/tests/test_api_analysis_execution_v0424_compat.py -q`
   - 25 passed
   - DataRobot deployment 互換 endpoint への round-trip smoke を含む。
+- `uv run pytest app_backend/tests/test_llm_model_constants.py app_backend/tests/test_llm_client.py::test_async_llm_client_deployed_llm_uses_provider_when_default_model_missing customize_docs/test_llm_runtime_parameters.py -q`
+  - RED: 5 failed
+  - GREEN: 5 passed
+- `uv run pytest app_backend/tests/test_llm_client.py app_backend/tests/test_llm_model_constants.py app_backend/tests/test_llm_configuration.py app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_llm_timeout.py app_backend/tests/test_base_telemetry.py customize_docs/test_llm_runtime_parameters.py -q`
+  - 34 passed
 - `uv run pytest app_backend/tests customize_docs -q`
   - 108 passed, 2 skipped
 

--- a/customize_docs/test_llm_runtime_parameters.py
+++ b/customize_docs/test_llm_runtime_parameters.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[1]
+
+
+def _keyword_constant(call: ast.Call, name: str) -> str | None:
+    for keyword in call.keywords:
+        if keyword.arg == name and isinstance(keyword.value, ast.Constant):
+            return keyword.value.value if isinstance(keyword.value.value, str) else None
+    return None
+
+
+def test_app_runtime_parameters_include_llm_default_model() -> None:
+    source = (REPO_ROOT / "infra" / "__main__.py").read_text()
+    tree = ast.parse(source)
+
+    runtime_parameter_keys = {
+        key
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        for key in [_keyword_constant(node, "key")]
+        if key is not None
+    }
+
+    assert "LLM_DEFAULT_MODEL" in runtime_parameter_keys

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -41,6 +41,7 @@ from infra.components.dr_credential import (
     get_database_credentials,
     get_llm_credentials,
 )
+from infra.configurations.llm import DEFAULT_DEPLOYED_MODEL, configured_model
 from infra.settings_database import DATABASE_CONNECTION_TYPE
 from infra.settings_proxy_llm import CHAT_MODEL_NAME
 from utils.customize.csv_validator import (
@@ -58,6 +59,7 @@ from utils.schema import AppInfra
 
 TEXTGEN_DEPLOYMENT_ID = os.environ.get("TEXTGEN_DEPLOYMENT_ID")
 TEXTGEN_REGISTERED_MODEL_ID = os.environ.get("TEXTGEN_REGISTERED_MODEL_ID")
+LLM_DEFAULT_MODEL = configured_model(os.environ, DEFAULT_DEPLOYED_MODEL)
 USE_DATAROBOT_LLM_GATEWAY = (
     os.environ.get("USE_DATAROBOT_LLM_GATEWAY", "false").lower() == "true"
 )
@@ -212,6 +214,11 @@ app_runtime_parameters = [
         key=llm_deployment_env_name,
         type="deployment",
         value=llm_deployment.id,
+    ),
+    datarobot.ApplicationSourceRuntimeParameterValueArgs(
+        key="LLM_DEFAULT_MODEL",
+        type="string",
+        value=LLM_DEFAULT_MODEL,
     ),
     datarobot.ApplicationSourceRuntimeParameterValueArgs(
         key="APP_LOCALE", type="string", value=LocaleSettings().app_locale


### PR DESCRIPTION
## Summary
- Align deployed LLM model resolution with upstream by adding DataRobot provider-prefix normalization through `get_llm_model()`.
- Pass `LLM_DEFAULT_MODEL` as an app runtime parameter from the current infra entrypoint.
- Keep a runtime fallback in `AsyncLLMClient` so existing deployments without `LLM_DEFAULT_MODEL` still send `datarobot/datarobot-deployed-llm` to LiteLLM.
- Add regression coverage and update the investigation note for `litellm.BadRequestError: LLM Provider NOT provided`.

## Root Cause
The fork current `infra/__main__.py` passed only the LLM deployment id to the app, while upstream also passes `LLM_DEFAULT_MODEL`. When that runtime parameter was absent, chat calls could pass the generic alias `datarobot-deployed-llm` directly to LiteLLM, which requires a provider prefix for routing.

## Validation
- `uv run pytest app_backend/tests customize_docs -q` -> 113 passed, 2 skipped
- `uv run ruff check core/src/core/constants.py core/src/core/llm_client.py infra/__main__.py app_backend/tests/test_llm_client.py app_backend/tests/test_llm_model_constants.py customize_docs/test_llm_runtime_parameters.py` -> passed