### PR TITLE
[codex] Preserve LiteLLM shared async clients

### DIFF
--- a/app_backend/tests/test_llm_client.py
+++ b/app_backend/tests/test_llm_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import sys
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from types import SimpleNamespace
@@ -398,6 +399,47 @@ def test_async_llm_client_deployed_llm_uses_provider_when_default_model_missing(
         "deployment-123/chat/completions"
     )
     assert completions.kwargs["model"] == "datarobot/datarobot-deployed-llm"
+
+
+def test_async_llm_client_litellm_exit_does_not_close_shared_async_clients(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("USE_DATAROBOT_LLM_GATEWAY", "true")
+    monkeypatch.setenv("LLM_DEFAULT_MODEL", "datarobot/bedrock/test-model")
+    completions = _RecordingCompletions()
+    cleanup_calls = 0
+
+    async def fake_acompletion(**_kwargs: Any) -> Any:
+        return "raw"
+
+    def fake_patch(*_args: Any, **_kwargs: Any) -> Any:
+        return completions.create
+
+    async def fake_close_litellm_async_clients() -> None:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+
+    monkeypatch.setattr(
+        llm_client,
+        "litellm",
+        SimpleNamespace(acompletion=fake_acompletion),
+        raising=False,
+    )
+    monkeypatch.setattr(llm_client.instructor, "patch", fake_patch)
+    monkeypatch.setitem(
+        sys.modules,
+        "litellm.llms.custom_httpx.async_client_cleanup",
+        SimpleNamespace(close_litellm_async_clients=fake_close_litellm_async_clients),
+    )
+
+    async def run_client() -> None:
+        async with AsyncLLMClient():
+            pass
+
+    asyncio.run(run_client())
+
+    assert cleanup_calls == 0
 
 
 def test_async_llm_client_deployed_llm_create_round_trips_to_deployment_endpoint() -> (

--- a/core/src/core/llm_client.py
+++ b/core/src/core/llm_client.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
-from contextlib import suppress
 from dataclasses import dataclass, replace
 from types import TracebackType
 from typing import Any, Type
@@ -435,12 +434,5 @@ class AsyncLLMClient:
         exc_tb: TracebackType | None,
     ) -> None:
         """Clean up clients on context exit."""
-        if self._llm_config.should_use_litellm and litellm is not None:
-            with suppress(Exception):
-                from litellm.llms.custom_httpx.async_client_cleanup import (
-                    close_litellm_async_clients,
-                )
-
-                await close_litellm_async_clients()
         if self._openai_client:
             await self._openai_client.close()

--- a/customize_docs/dev_branch_runtime_error_investigation_20260616.md
+++ b/customize_docs/dev_branch_runtime_error_investigation_20260616.md
@@ -6,6 +6,7 @@
 - `RuntimeWarning: coroutine 'acompletion' was never awaited`
 - `opentelemetry.context: Failed to detach context`
 - `litellm.BadRequestError: LLM Provider NOT provided`
+- `litellm.APIConnectionError: DatarobotException - Cannot send a request, as the client has been closed`
 
 ## 調査方針
 
@@ -35,6 +36,14 @@ LiteLLM の DataRobot provider は provider prefix 付き model 名を routing �
 
 - `litellm.BadRequestError: LLM Provider NOT provided`
 
+### LiteLLM async client lifecycle
+
+upstream v11.5.1 / v11.8.2 は `AsyncLLMClient.__aexit__()` で LiteLLM の async HTTP client を明示 close しない。
+fork 側では `close_litellm_async_clients()` を context exit ごとに呼んでいたため、初期分析などで複数の LLM 呼び出しが連続・並行すると、別の LiteLLM リクエストが使う共有 client を先に閉じる可能性があった。
+その場合、以下が発生する。
+
+- `litellm.APIConnectionError: DatarobotException - Cannot send a request, as the client has been closed`
+
 ### OpenTelemetry
 
 `BaseTelemetry.trace()` の async generator ラッパーが `with tracer.start_as_current_span(...):` を開いたまま `yield` していた。
@@ -48,8 +57,8 @@ HTTP streaming やクライアント切断などで async generator が別の as
 - `core/src/core/llm_client.py`
   - LiteLLM 経路では `from_litellm()` を使わず、`instructor.AsyncInstructor` を明示構築する。
   - `instructor.patch(create=litellm.acompletion, mode=Mode.MD_JSON)` により、LiteLLM coroutine を await する adapter を使う。
-  - LiteLLM 経路の `AsyncLLMClient.__aexit__()` で `close_litellm_async_clients()` を await し、DataRobot deployment 呼び出し後の async HTTP client cleanup warning を防ぐ。
   - `LLM_DEFAULT_MODEL` が未設定の既存環境でも DataRobot deployment alias を `datarobot/datarobot-deployed-llm` に解決する。
+  - upstream と同様に、context exit では LiteLLM の共有 async client を閉じない。OpenAI legacy 経路の `AsyncOpenAI.close()` のみ維持する。
 - `core/src/core/constants.py`
   - upstream と同様に `get_llm_model()` を追加し、`LLM_DEFAULT_MODEL` または既定 alias に `datarobot/` provider prefix を補完する。
 - `infra/__main__.py`
@@ -68,6 +77,7 @@ HTTP streaming やクライアント切断などで async generator が別の as
   - `create_with_completion()` が async adapter 経由で `_raw_response` を取得できること。
   - model 解決、timeout、retry、token 引数変換、DataRobot deployment `api_base` 注入が維持されること。
   - `LLM_DEFAULT_MODEL` 未設定でも deployed LLM alias が provider prefix 付きに正規化されること。
+  - LiteLLM 経路の context exit で `close_litellm_async_clients()` に戻らないこと。
   - ローカルの OpenAI 互換 HTTP server を DataRobot deployment に見立て、`AsyncLLMClient` が `/api/v2/deployments/{id}/chat/completions/` に bearer token 付きで POST し、structured response を返せること。
 - `app_backend/tests/test_llm_model_constants.py`
   - `get_llm_model()` が upstream と同じ `datarobot/` provider prefix 補完を行うこと。
@@ -95,6 +105,9 @@ HTTP streaming やクライアント切断などで async generator が別の as
   - GREEN: 5 passed
 - `uv run pytest app_backend/tests/test_llm_client.py app_backend/tests/test_llm_model_constants.py app_backend/tests/test_llm_configuration.py app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_llm_timeout.py app_backend/tests/test_base_telemetry.py customize_docs/test_llm_runtime_parameters.py -q`
   - 34 passed
+- `uv run pytest app_backend/tests/test_llm_client.py::test_async_llm_client_litellm_exit_does_not_close_shared_async_clients -q`
+  - RED: `close_litellm_async_clients()` が呼ばれて失敗。
+  - GREEN: context exit で LiteLLM の共有 async client を閉じず、1 passed。
 - `uv run pytest app_backend/tests customize_docs -q`
   - 108 passed, 2 skipped
 


### PR DESCRIPTION
## Summary
- Align `AsyncLLMClient` lifecycle with upstream by no longer closing LiteLLM shared async HTTP clients on context exit.
- Add a regression test for the reported `Cannot send a request, as the client has been closed` error path.
- Document the upstream comparison and verification in `customize_docs/dev_branch_runtime_error_investigation_20260616.md`.

## Root cause
The fork closed LiteLLM shared async clients in `AsyncLLMClient.__aexit__`, while upstream leaves that lifecycle unmanaged at request-context exit. Closing the shared client can break later or concurrent LiteLLM requests with `DatarobotException - Cannot send a request, as the client has been closed`.

## Testing
- `uv run pytest app_backend/tests/test_llm_client.py::test_async_llm_client_litellm_exit_does_not_close_shared_async_clients -q`
- `uv run pytest app_backend/tests/test_llm_client.py -q`
- `uv run ruff format --check . && uv run ruff check .`
- `uv run pytest app_backend/tests customize_docs -q`