### PR TITLE
[codex] Handle pandas tuple column metadata

### DIFF
--- a/app_backend/tests/test_analyst_db_upstream_compat.py
+++ b/app_backend/tests/test_analyst_db_upstream_compat.py
@@ -50,6 +50,47 @@ def test_analyst_db_dataset_roundtrip_preserves_pandas(tmp_path, caplog) -> None
     asyncio.run(_assert_analyst_db_dataset_roundtrip_preserves_pandas(tmp_path, caplog))
 
 
+def test_register_dataset_normalizes_tuple_columns_for_metadata(tmp_path) -> None:
+    asyncio.run(
+        _assert_register_dataset_normalizes_tuple_columns_for_metadata(tmp_path)
+    )
+
+
+async def _assert_register_dataset_normalizes_tuple_columns_for_metadata(
+    tmp_path,
+) -> None:
+    analyst_db = await AnalystDB.create(user_id="user-1", db_path=tmp_path)
+    source_df = pd.DataFrame(
+        [[0, 1, 0, 1]],
+        columns=pd.Index(
+            [
+                ("black_friday", 0.0),
+                ("black_friday", 1.0),
+                ("holiday", 0.0),
+                ("holiday", 1.0),
+            ]
+        ),
+    )
+    dataset = AnalystDataset(name="events", data=source_df)
+
+    result = await analyst_db.register_dataset(
+        dataset,
+        data_source=InternalDataSourceType.FILE,
+    )
+    metadata = await analyst_db.get_dataset_metadata("events")
+    restored = await analyst_db.get_dataset("events")
+
+    assert result == {"success": True, "msg": ""}
+    assert metadata.columns == [
+        "('black_friday', '0.0')",
+        "('black_friday', '1.0')",
+        "('holiday', '0.0')",
+        "('holiday', '1.0')",
+    ]
+    assert all(isinstance(column, str) for column in metadata.columns)
+    assert restored.to_df().columns.tolist() == metadata.columns
+
+
 async def _assert_analyst_db_dataset_roundtrip_preserves_pandas(
     tmp_path,
     caplog,

--- a/app_backend/tests/test_schema_pandas_compat.py
+++ b/app_backend/tests/test_schema_pandas_compat.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from utils.schema import DataDictionary
+
+
+def test_data_dictionary_from_analyst_df_stringifies_tuple_columns() -> None:
+    df = pd.DataFrame(
+        [[100, 200]],
+        columns=pd.Index(
+            [
+                ("black_friday", 0.0),
+                ("holiday", 1.0),
+            ]
+        ),
+    )
+
+    dictionary = DataDictionary.from_analyst_df(df)
+
+    assert [column.column for column in dictionary.column_descriptions] == [
+        "('black_friday', 0.0)",
+        "('holiday', 1.0)",
+    ]
+    assert [column.data_type for column in dictionary.column_descriptions] == [
+        "int64",
+        "int64",
+    ]

--- a/core/src/core/analyst_db.py
+++ b/core/src/core/analyst_db.py
@@ -536,7 +536,7 @@ class DatasetHandler(BaseDuckDBHandler):
                 external_id=external_id,
                 original_name=original_name or name,
                 created_at=datetime.now(timezone.utc),
-                columns=list(df.columns),
+                columns=list(arrow_table.schema.names),
                 row_count=len(df),
                 data_source=data_source,
                 file_size=file_size,

--- a/core/src/core/schema.py
+++ b/core/src/core/schema.py
@@ -354,7 +354,7 @@ class DataDictionary(BaseModel):
             name=name,
             column_descriptions=[
                 DataDictionaryColumn(
-                    column=col,
+                    column=str(col),
                     description=column_descriptions,
                     data_type=str(df[col].dtype),
                 )

--- a/customize_docs/dataset_metadata_tuple_columns_investigation_20260616.md
+++ b/customize_docs/dataset_metadata_tuple_columns_investigation_20260616.md
@@ -1,0 +1,83 @@
+# DatasetMetadata tuple columns investigation 2026-06-16
+
+## User-facing error
+
+Initial analysis failed while registering a pandas dataset whose columns included tuple labels:
+
+```text
+8 validation errors for DatasetMetadata
+columns.36 Input should be a valid string [type=string_type, input_value=('black_friday', 0.0), input_type=tuple]
+```
+
+## Root cause
+
+`DatasetMetadata.columns` is typed as `list[str]`. The fork keeps the public dataframe path on pandas, where column labels may be arbitrary hashable values, including tuples and `MultiIndex` labels.
+
+Before this fix, `DatasetHandler.register_dataframe()` passed `list(df.columns)` into `DatasetMetadata`. For tuple-labeled pandas columns this produced `list[tuple[...]]`, which Pydantic rejected before metadata could be stored.
+
+`pyarrow.Table.from_pandas(..., preserve_index=False)` already normalizes those labels into the string column names used when the table is registered in DuckDB, for example:
+
+```python
+[("black_friday", 0.0)] -> ["('black_friday', '0.0')"]
+```
+
+The fix stores metadata columns from `arrow_table.schema.names`, so metadata and the registered DuckDB table use the same string column names.
+
+## Additional minimal compatibility fix
+
+`DataDictionary.from_analyst_df()` also assumed that every dataframe column label was already a string. That is safe for the upstream Polars implementation, but pandas analysis result dataframes can still contain tuple labels after operations such as `pivot` or `groupby().unstack()`.
+
+The minimal fix stringifies the `DataDictionaryColumn.column` value while keeping the existing pandas dtype lookup unchanged. This prevents the same Pydantic `string_type` validation error when a business-analysis dictionary is built from a pandas analysis result.
+
+## Upstream comparison
+
+Upstream v11.5.1 and upstream main already use `polars.DataFrame` in `DatasetHandler.register_dataframe()`. Polars column names are strings, so `columns=list(df.columns)` is safe there.
+
+This fork intentionally preserved pandas in the dataset roundtrip layer. That means the upstream implementation pattern cannot be copied directly without either converting the whole path to Polars or normalizing pandas column labels at the storage boundary. The minimal compatible fix is to normalize via the PyArrow schema that is already used for table creation.
+
+## Version comparison
+
+Observed local app backend environment:
+
+- `pydantic==2.7.4`
+- `pandas==2.3.3`
+- `polars==1.41.2`
+- `pyarrow==18.1.0`
+- `datarobot==3.16.0`
+- `litellm==1.80.0`
+- `scikit-learn==1.7.2`
+
+Upstream v11.5.1 lock snapshot:
+
+- `pydantic==2.12.5`
+- `pandas==2.3.3`
+- `polars==1.36.1`
+- `pyarrow==18.1.0`
+- `datarobot==3.10.0`
+- `litellm==1.80.0`
+- `scikit-learn==1.7.2`
+
+Upstream main app backend lock snapshot:
+
+- `pydantic==2.12.5`
+- `pandas==2.3.3`
+- `polars==1.36.1`
+- `pyarrow==20.0.0`
+- `datarobot==3.14.0`
+- `litellm==1.80.0`
+- `scikit-learn==1.7.2`
+
+The failure is not primarily caused by a library version mismatch. It is caused by pandas accepting tuple column labels while the Pydantic model requires strings. Newer Pydantic also expects `list[str]` elements to be strings, so the same invalid metadata input remains unsafe.
+
+## Tests
+
+Added a regression test:
+
+```text
+uv run pytest app_backend/tests/test_analyst_db_upstream_compat.py::test_register_dataset_normalizes_tuple_columns_for_metadata -q
+uv run pytest app_backend/tests/test_schema_pandas_compat.py::test_data_dictionary_from_analyst_df_stringifies_tuple_columns -q
+```
+
+The test registers a pandas dataset with tuple column labels, verifies registration succeeds, and checks that `DatasetMetadata.columns` are strings matching the restored DuckDB dataframe columns.
+
+The second test builds a `DataDictionary` from a pandas dataframe with tuple column labels and verifies dictionary column names are strings.


### PR DESCRIPTION
## Summary
- Normalize pandas tuple column labels when storing `DatasetMetadata` by using the PyArrow schema names that DuckDB receives.
- Stringify `DataDictionaryColumn.column` in `DataDictionary.from_analyst_df()` to avoid Pydantic string validation errors for pandas analysis results with tuple columns.
- Add regression tests and document the upstream comparison and dependency versions.

## Root cause
Upstream v11.5.1 and upstream main use Polars in the dataset registration path, where column names are strings. This fork preserves pandas, and pandas allows tuple or MultiIndex column labels. Passing those labels directly into Pydantic fields typed as `list[str]` or `str` caused `string_type` validation errors during initial analysis and follow-on dictionary generation.

## Testing
- `uv run pytest app_backend/tests/test_schema_pandas_compat.py app_backend/tests/test_analyst_db_upstream_compat.py -q`
- `uv run ruff format --check . && uv run ruff check .`
- `uv run pytest app_backend/tests customize_docs -q`