### PR TITLE
[codex] Restore Pulumi up workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,14 +9,22 @@ CI/CD, releases, and repository synchronization.
 
 Below is a list of the workflows included in this repository:
 
-| Workflow File                  | Purpose                                                           |
-|--------------------------------|-------------------------------------------------------------------|
-| `dockerfile-lint.yml`          | Run Hadolint to check Dockerfiles for best practices.             |
-| `license-check.yml`            | Check and fix license headers and resolve dependencies' licenses. |
-| `python-static-checks.yml`     | Run Ruff linter and formatter, and MyPy static type checks.       |
-| `python-deps-install-test.yml` | Verify Python dependencies install for different Python versions. |
-| `shellcheck.yml`               | Run [shellcheck](https://github.com/koalaman/shellcheck/).        |
-| `yaml-format.yml`              | Run YAML linter tool (yamlfmt).                                   |
+| Workflow File             | Purpose                                                              |
+|---------------------------|----------------------------------------------------------------------|
+| `app_backend-test.yml`    | Build the React assets, then run app_backend lint and tests.          |
+| `app_frontend-vitest.yml` | Run React lint, Vitest, Knip, and coverage reporting.                 |
+| `core-python.yml`         | Run core package lint and tests across supported Python versions.     |
+| `dockerfile-lint.yml`     | Run Hadolint to check Dockerfiles for best practices.                 |
+| `frontend-test.yml`       | Run legacy frontend Python checks.                                    |
+| `infra-python.yml`        | Run infra package lint checks across supported Python versions.       |
+| `pulumi-up.yml`           | Run Pulumi `up --refresh` after merges to `main` or `dev`.            |
+| `shellcheck.yml`          | Run [shellcheck](https://github.com/koalaman/shellcheck/).            |
+| `yaml-format.yml`         | Run YAML linter tool (yamlfmt).                                       |
+
+`pulumi-up.yml` is a repository-specific CD workflow restored on top of the
+upstream split CI workflow layout. It deploys from the `infra/` Pulumi project
+and expects the DataRobot, Pulumi, and OpenAI credentials to be configured as
+GitHub environment secrets.
 
 ---
 

--- a/.github/workflows/pulumi-up.yml
+++ b/.github/workflows/pulumi-up.yml
@@ -1,0 +1,136 @@
+---
+name: Pulumi Up
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pulumi-up-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Pulumi Update
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    environment: main
+    env:
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+      PULUMI_STACK_NAME: ${{ github.ref == 'refs/heads/main' && 'ryosukehata/dataanalyst/ttmd-pandas-react' || 'ryosukehata/dataanalyst/dev'
+        }}
+      DATAROBOT_API_TOKEN: ${{ secrets.DATAROBOT_API_TOKEN }}
+      DATAROBOT_ENDPOINT: ${{ secrets.DATAROBOT_ENDPOINT }}
+      DATAROBOT_DEFAULT_USE_CASE: ${{ secrets.DATAROBOT_DEFAULT_USE_CASE }}
+      APP_ENVIRONMENT_ID: ${{ secrets.APP_ENVIRONMENT_ID }}
+      INFRA_ENABLE_LLM: blueprint_with_external_llm.py
+      LLM_DEFAULT_MODEL: ${{ vars.LLM_DEFAULT_MODEL || secrets.LLM_DEFAULT_MODEL || 'azure/gpt-4o' }}
+      LLM_DEFAULT_LLM_ID: ${{ vars.LLM_DEFAULT_LLM_ID || secrets.LLM_DEFAULT_LLM_ID || 'azure-openai-gpt-4-o' }}
+      LLM_DEFAULT_LLM_NAME: ${{ vars.LLM_DEFAULT_LLM_NAME || secrets.LLM_DEFAULT_LLM_NAME || 'Azure OpenAI GPT-4o' }}
+      USE_BUILDER_API_TOKEN: ${{ vars.USE_BUILDER_API_TOKEN || 'false' }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
+      OPENAI_API_VERSION: ${{ secrets.OPENAI_API_VERSION }}
+      OPENAI_API_DEPLOYMENT_ID: ${{ secrets.OPENAI_API_DEPLOYMENT_ID }}
+      FRONTEND_TYPE: ${{ vars.FRONTEND_TYPE || 'react' }}
+      SKIP_PULUMI_FRONTEND_BUILD: "true"
+      SKIP_PULUMI_CUSTOM_JOBS: "true"
+      DISALLOW_MONITORING_RESOURCES: "true"
+      VITE_ENABLE_TEMPLATE_EDIT: ${{ secrets.VITE_ENABLE_TEMPLATE_EDIT }}
+      VITE_ENABLE_CUSTOM_PROMPTS: ${{ secrets.VITE_ENABLE_CUSTOM_PROMPTS }}
+      PROMPTS_TEMPLATE_PATH: ${{ secrets.PROMPTS_TEMPLATE_PATH }}
+      VITE_ENABLE_QUESTION_REFINER: ${{ secrets.VITE_ENABLE_QUESTION_REFINER }}
+      VITE_ENABLE_REFINER_AUTO_SEND: ${{ secrets.VITE_ENABLE_REFINER_AUTO_SEND }}
+      VITE_ENABLE_REPORT_BUILDER: ${{ secrets.VITE_ENABLE_REPORT_BUILDER }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          working-directory: infra
+          python-version: "3.11"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install Taskfile
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install infra dependencies
+        working-directory: infra
+        run: task install
+
+      - name: Prepare application infra manifest for Pulumi refresh
+        run: |
+          cat > app_backend/app_infra.json <<'EOF'
+          {"llm":"llm","database":"no_database"}
+          EOF
+
+      - name: Build frontend assets for Pulumi refresh
+        working-directory: app_frontend
+        run: |
+          npm install
+          npm run build
+
+      - name: Restore ApplicationSource files for Pulumi refresh
+        working-directory: infra
+        run: |
+          uv run pulumi stack export --stack "$PULUMI_STACK_NAME" --file /tmp/pulumi-stack.json --non-interactive
+          uv run python ../.github/scripts/prepare_pulumi_refresh_files.py /tmp/pulumi-stack.json --workspace "$GITHUB_WORKSPACE"
+
+      - name: Remove stale Pulumi state resources
+        working-directory: infra
+        run: |
+          project_name="dev"
+          if [ "$GITHUB_REF_NAME" = "main" ]; then
+            project_name="ttmd-pandas-react"
+          fi
+
+          uv run python ../.github/scripts/prune_pulumi_state_resources.py \
+            /tmp/pulumi-stack.json \
+            /tmp/pulumi-stack-pruned.json \
+            custom:resource:CustomJobPostActions \
+            custom:resource:CustomJobScheduleCleanup \
+            command:local:Command \
+            datarobot:index/customJob:CustomJob \
+            datarobot:index:CustomJob \
+            --resource-name "Data Analyst App Source [$project_name]" \
+            --resource-name "Data Analyst Dashboard Source [$project_name]" \
+            --resource-name "Data Analyst Dashboard [$project_name]" \
+            --resource-name "Dataset Trace [$project_name]" \
+            --resource-name "Dataset Access Log [$project_name]" \
+            > /tmp/pruned-urns.txt
+
+          stale_urns="$(cat /tmp/pruned-urns.txt)"
+          if [ -z "$stale_urns" ]; then
+            echo "No stale Pulumi state resources found"
+            exit 0
+          fi
+
+          while IFS= read -r urn; do
+            echo "Pruning stale Pulumi state resource: $urn"
+          done < /tmp/pruned-urns.txt
+
+          uv run pulumi stack import --stack "$PULUMI_STACK_NAME" --file /tmp/pulumi-stack-pruned.json --non-interactive
+
+      - name: Run Pulumi Up
+        uses: pulumi/actions@v6
+        with:
+          command: up
+          stack-name: ${{ env.PULUMI_STACK_NAME }}
+          work-dir: infra
+          refresh: true

--- a/customize_docs/application_source_file_manifest.md
+++ b/customize_docs/application_source_file_manifest.md
@@ -30,6 +30,8 @@ GitHub Actions の Pulumi CD で、DataRobot `ApplicationSource` 更新時に `f
 - `customize_docs/test_application_source_retention.py`
   - App と Dashboard の `ApplicationSource` に `retain_on_delete=True` が設定されていることを検証する。
 - `.github/workflows/pulumi-up.yml`
-  - YAML として parse できること、refresh 前の `app_infra.json` 作成 step、frontend build step、state file 補完 step があること、main/dev 両方の Pulumi action に `refresh: true` が設定されていることを確認する。
+  - YAML として parse できること、`main` / `dev` push で起動すること、`infra/` Pulumi project を `work-dir` にして `refresh: true` 付きの Pulumi update を実行することを確認する。
+  - refresh 前の `app_infra.json` 作成 step、frontend build step、state file 補完 step、stale resource prune step があることを確認する。
+  - CD の LLM 設定は従来の OpenAI 利用に合わせて `blueprint_with_external_llm.py` を使い、`OPENAI_*` secrets と `LLM_DEFAULT_*` 値を渡す。
 - `.github/scripts/prepare_pulumi_refresh_files.py`
   - Pulumi state の ApplicationSource `files` から missing file を抽出し、同種の現在 asset または placeholder で補完できることを確認する。

--- a/customize_docs/test_pulumi_workflow_refresh.py
+++ b/customize_docs/test_pulumi_workflow_refresh.py
@@ -15,9 +15,86 @@ def _step_by_name(steps: list[dict], name: str) -> dict:
     return next(step for step in steps if step.get("name") == name)
 
 
-def test_removed_legacy_python_workflows_stay_removed() -> None:
-    assert not (WORKFLOWS_DIR / "pulumi-up.yml").exists()
+def _workflow_triggers(workflow: dict) -> dict:
+    return workflow.get("on") or workflow[True]
+
+
+def test_legacy_python_unit_workflow_stays_removed() -> None:
     assert not (WORKFLOWS_DIR / "python-unit-tests.yml").exists()
+
+
+def test_pulumi_up_workflow_deploys_from_split_infra_project() -> None:
+    workflow = _load_workflow("pulumi-up.yml")
+    triggers = _workflow_triggers(workflow)
+    job = workflow["jobs"]["update"]
+    steps = job["steps"]
+
+    assert triggers["push"]["branches"] == ["main", "dev"]
+    assert "workflow_dispatch" in triggers
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["concurrency"] == {
+        "group": "pulumi-up-${{ github.ref_name }}",
+        "cancel-in-progress": False,
+    }
+    assert job["environment"] == "main"
+    assert job["env"]["PULUMI_STACK_NAME"] == (
+        "${{ github.ref == 'refs/heads/main' && "
+        "'ryosukehata/dataanalyst/ttmd-pandas-react' || "
+        "'ryosukehata/dataanalyst/dev' }}"
+    )
+    assert job["env"]["INFRA_ENABLE_LLM"] == "blueprint_with_external_llm.py"
+    assert job["env"]["LLM_DEFAULT_MODEL"] == (
+        "${{ vars.LLM_DEFAULT_MODEL || secrets.LLM_DEFAULT_MODEL || "
+        "'azure/gpt-4o' }}"
+    )
+    assert job["env"]["LLM_DEFAULT_LLM_ID"] == (
+        "${{ vars.LLM_DEFAULT_LLM_ID || secrets.LLM_DEFAULT_LLM_ID || "
+        "'azure-openai-gpt-4-o' }}"
+    )
+    assert job["env"]["LLM_DEFAULT_LLM_NAME"] == (
+        "${{ vars.LLM_DEFAULT_LLM_NAME || secrets.LLM_DEFAULT_LLM_NAME || "
+        "'Azure OpenAI GPT-4o' }}"
+    )
+    assert "TEXTGEN_DEPLOYMENT_ID" not in job["env"]
+    assert job["env"]["OPENAI_API_KEY"] == "${{ secrets.OPENAI_API_KEY }}"
+
+    install_step = _step_by_name(steps, "Install infra dependencies")
+    assert install_step == {
+        "name": "Install infra dependencies",
+        "working-directory": "infra",
+        "run": "task install",
+    }
+
+    manifest_step = _step_by_name(
+        steps, "Prepare application infra manifest for Pulumi refresh"
+    )
+    assert '{"llm":"llm","database":"no_database"}' in manifest_step["run"]
+
+    build_step = _step_by_name(steps, "Build frontend assets for Pulumi refresh")
+    assert build_step["working-directory"] == "app_frontend"
+    assert "npm install" in build_step["run"]
+    assert "npm run build" in build_step["run"]
+
+    restore_step = _step_by_name(
+        steps, "Restore ApplicationSource files for Pulumi refresh"
+    )
+    assert restore_step["working-directory"] == "infra"
+    assert "uv run pulumi stack export" in restore_step["run"]
+    assert "../.github/scripts/prepare_pulumi_refresh_files.py" in restore_step["run"]
+
+    prune_step = _step_by_name(steps, "Remove stale Pulumi state resources")
+    assert prune_step["working-directory"] == "infra"
+    assert "../.github/scripts/prune_pulumi_state_resources.py" in prune_step["run"]
+    assert "uv run pulumi stack import" in prune_step["run"]
+
+    pulumi_step = _step_by_name(steps, "Run Pulumi Up")
+    assert pulumi_step["uses"] == "pulumi/actions@v6"
+    assert pulumi_step["with"] == {
+        "command": "up",
+        "stack-name": "${{ env.PULUMI_STACK_NAME }}",
+        "work-dir": "infra",
+        "refresh": True,
+    }
 
 
 def test_infra_python_workflow_runs_split_infra_checks() -> None:

--- a/customize_docs/v11_5_3_infra_integration_plan.md
+++ b/customize_docs/v11_5_3_infra_integration_plan.md
@@ -40,3 +40,4 @@ upstream `v11.5.3` のうち、デプロイ・runtime parameter・起動資材�
   - `uv run pytest customize_docs/test_v11_5_3_infra_config.py -q`: 5 passed
 - 2026-06-26 追加follow-upで、`infra/Pulumi.yaml` / `infra/infra/*` / `infra/feature_flags/*` を upstream 型へ移行した。旧 `infra/settings_*` と直下 `infra/components` は削除し、既存のApplicationSource manifest、optional custom jobs、monitoring、cleanup jobは `infra/infra/app_backend.py` に移した。
 - 2026-06-27 追加follow-upで、実デプロイ済みTextGen deploymentを使う構成に合わせ、既定の `infra/infra/llm.py` symlink、`.datarobot/cli/llm.yml` のdefault、`.env.template`、READMEを `deployed_llm.py` 基準へ変更した。
+- 2026-06-27 CD復元PRで、upstreamの分割CI構成は維持しつつ、このリポジトリ固有の `.github/workflows/pulumi-up.yml` を再追加した。workflowは `main` / `dev` へのpushで `infra/` Pulumi projectから `pulumi up --refresh` を実行し、従来のOpenAI利用に合わせて `blueprint_with_external_llm.py` と `OPENAI_*` secrets を使う。


### PR DESCRIPTION
## Summary

- Restore `.github/workflows/pulumi-up.yml` as a repository-specific CD workflow on top of the upstream split CI layout.
- Run Pulumi from the current `infra/` project with `refresh: true` after pushes to `main` or `dev`.
- Use the previous OpenAI-backed LLM path by setting `INFRA_ENABLE_LLM=blueprint_with_external_llm.py` and passing `OPENAI_*` plus `LLM_DEFAULT_*` values.
- Update workflow documentation and customize_docs characterization tests.

## Validation

- `yamlfmt -conf .yamlfmt.yml -lint .github/workflows/pulumi-up.yml`
- `uv run pytest customize_docs/test_pulumi_workflow_refresh.py -q`
- `uv run pytest customize_docs/test_taskfile_deployment_dx.py customize_docs/test_application_source_file_manifest.py -q`
- `uv run pytest customize_docs -q`
- `uv run ruff check customize_docs/test_pulumi_workflow_refresh.py`

## Notes

This is intentionally a stacked PR targeting `codex/v1153-infra`, so the diff stays limited to the CD workflow restoration.