### PR TITLE
[codex] Stabilize upstream-aligned pandas analysis

### DIFF
--- a/app_backend/tests/test_analyst_db_upstream_compat.py
+++ b/app_backend/tests/test_analyst_db_upstream_compat.py
@@ -3,6 +3,7 @@ import logging
 import os
 from datetime import datetime, timezone
 
+import numpy as np
 import pandas as pd
 
 os.environ.setdefault("DATAROBOT_API_TOKEN", "test-token")
@@ -17,7 +18,13 @@ from utils.analyst_db import (
     InternalDataSourceType,
     get_data_source_type,
 )
-from utils.schema import AnalystDataset
+from utils.chat_dataset_helper import extract_and_store_datasets
+from utils.schema import (
+    AnalystChatMessage,
+    AnalystDataset,
+    RunAnalysisResult,
+    RunAnalysisResultMetadata,
+)
 
 
 def test_get_data_source_type_accepts_internal_string_values() -> None:
@@ -54,6 +61,61 @@ def test_register_dataset_normalizes_tuple_columns_for_metadata(tmp_path) -> Non
     asyncio.run(
         _assert_register_dataset_normalizes_tuple_columns_for_metadata(tmp_path)
     )
+
+
+def test_extract_and_store_datasets_handles_numpy_bool_mixed_object_column(
+    tmp_path,
+) -> None:
+    asyncio.run(
+        _assert_extract_and_store_datasets_handles_numpy_bool_mixed_object_column(
+            tmp_path
+        )
+    )
+
+
+async def _assert_extract_and_store_datasets_handles_numpy_bool_mixed_object_column(
+    tmp_path,
+) -> None:
+    analyst_db = await AnalystDB.create(user_id="user-1", db_path=tmp_path)
+    source_df = pd.DataFrame(
+        {
+            "項目": ["A", "B", "C"],
+            "最小値": [1.0, np.False_, 3.2],
+            "有効": [True, False, True],
+            "件数": [10, 20, 30],
+        }
+    )
+    message = AnalystChatMessage(
+        role="assistant",
+        content="analysis",
+        components=[
+            RunAnalysisResult(
+                status="success",
+                dataset=AnalystDataset(name="analysis_result", data=source_df),
+                metadata=RunAnalysisResultMetadata(
+                    duration=0,
+                    attempts=1,
+                    datasets_analyzed=1,
+                ),
+            )
+        ],
+        in_progress=True,
+    )
+
+    stored_message = await extract_and_store_datasets(analyst_db, message)
+    stored_component = stored_message.components[0]
+    assert isinstance(stored_component, RunAnalysisResult)
+    assert stored_component.dataset_id is not None
+
+    restored = await analyst_db.dataset_handler.get_dataframe(
+        stored_component.dataset_id,
+        expected_type=DatasetType.ANALYST_RESULT_DATASET,
+        max_rows=None,
+    )
+
+    assert restored["最小値"].tolist() == ["1.0", "False", "3.2"]
+    assert restored["有効"].tolist() == [True, False, True]
+    assert restored["件数"].tolist() == [10, 20, 30]
 
 
 async def _assert_register_dataset_normalizes_tuple_columns_for_metadata(

--- a/app_backend/tests/test_api_analysis_execution_v0424_compat.py
+++ b/app_backend/tests/test_api_analysis_execution_v0424_compat.py
@@ -504,9 +504,7 @@ async def _assert_run_complete_analysis_stages_results_and_yields_business_once(
         result for result in results if isinstance(result, GetBusinessAnalysisResult)
     ]
     assert len(business_results) == 1
-    assert "ANALYZING_RESULTS" in [
-        message.step_value for message in analyst_db.updates
-    ]
+    assert "ANALYZING_RESULTS" in [message.step_value for message in analyst_db.updates]
 
 
 def test_run_complete_analysis_outer_exception_uses_friendly_llm_error(
@@ -857,7 +855,9 @@ async def _assert_run_database_analysis_passes_generator_context_without_argumen
 def test_run_database_analysis_updates_steps_with_analysis_context(
     monkeypatch,
 ) -> None:
-    asyncio.run(_assert_run_database_analysis_updates_steps_with_analysis_context(monkeypatch))
+    asyncio.run(
+        _assert_run_database_analysis_updates_steps_with_analysis_context(monkeypatch)
+    )
 
 
 async def _assert_run_database_analysis_updates_steps_with_analysis_context(

--- a/app_backend/tests/test_api_analysis_execution_v0424_compat.py
+++ b/app_backend/tests/test_api_analysis_execution_v0424_compat.py
@@ -30,6 +30,7 @@ from utils.schema import (
     AnalystDataset,
     ChatRequest,
     CodeGeneration,
+    GetBusinessAnalysisResult,
     RunAnalysisRequest,
     RunAnalysisResult,
     RunAnalysisResultMetadata,
@@ -394,6 +395,197 @@ async def _assert_run_complete_analysis_passes_tracker_and_telemetry_to_run_anal
     )
 
 
+def test_run_complete_analysis_stages_results_and_yields_business_once(
+    monkeypatch,
+) -> None:
+    asyncio.run(
+        _assert_run_complete_analysis_stages_results_and_yields_business_once(
+            monkeypatch
+        )
+    )
+
+
+async def _assert_run_complete_analysis_stages_results_and_yields_business_once(
+    monkeypatch,
+) -> None:
+    class FakeAnalystDB:
+        def __init__(self) -> None:
+            self.user_message = AnalystChatMessage(
+                id="user-1",
+                role="user",
+                content="sum amount",
+                components=[],
+                in_progress=True,
+            )
+            self.updates: list[AnalystChatMessage] = []
+
+        async def get_chat_message(self, message_id: str) -> AnalystChatMessage | None:
+            if message_id == "user-1":
+                return self.user_message
+            return None
+
+        async def add_chat_message(
+            self, chat_id: str, message: AnalystChatMessage
+        ) -> str:
+            assert chat_id == "chat-1"
+            message.id = "assistant-1"
+            return message.id
+
+        async def update_chat_message(
+            self, message_id: str, message: AnalystChatMessage
+        ) -> None:
+            assert message_id in {"user-1", "assistant-1"}
+            self.updates.append(message.model_copy(deep=True))
+
+    async def fake_rephrase_message(*args, **kwargs) -> str:
+        return "enhanced question"
+
+    async def fake_run_analysis(*args, **kwargs) -> RunAnalysisResult:
+        return RunAnalysisResult(
+            status="success",
+            dataset=AnalystDataset(
+                name="analysis_result",
+                data=pd.DataFrame({"total_amount": [300]}),
+            ),
+            metadata=RunAnalysisResultMetadata(
+                duration=0,
+                attempts=1,
+                datasets_analyzed=1,
+            ),
+        )
+
+    async def fake_extract_and_store_datasets(
+        analyst_db: FakeAnalystDB,
+        assistant_message: AnalystChatMessage,
+    ) -> AnalystChatMessage:
+        return assistant_message
+
+    async def fake_execute_business_analysis_and_charts(*args, **kwargs):
+        return (
+            None,
+            GetBusinessAnalysisResult(
+                status="success",
+                bottom_line="total is 300",
+                additional_insights="sales are stable",
+                follow_up_questions=["by month?"],
+            ),
+        )
+
+    monkeypatch.setattr(api, "rephrase_message", fake_rephrase_message)
+    monkeypatch.setattr(api, "run_analysis", fake_run_analysis)
+    monkeypatch.setattr(
+        api, "extract_and_store_datasets", fake_extract_and_store_datasets
+    )
+    monkeypatch.setattr(
+        api,
+        "execute_business_analysis_and_charts",
+        fake_execute_business_analysis_and_charts,
+    )
+
+    analyst_db = FakeAnalystDB()
+    results = [
+        component
+        async for component in api.run_complete_analysis(
+            chat_request=ChatRequest(
+                messages=[{"role": "user", "content": "sum amount"}]
+            ),
+            data_source=InternalDataSourceType.FILE,
+            dataset_metadata=[_dataset_metadata("sales")],
+            analyst_db=analyst_db,  # type: ignore[arg-type]
+            chat_id="chat-1",
+            message_id="user-1",
+            request=None,
+            enable_chart_generation=False,
+            enable_business_insights=True,
+        )
+    ]
+
+    business_results = [
+        result for result in results if isinstance(result, GetBusinessAnalysisResult)
+    ]
+    assert len(business_results) == 1
+    assert "ANALYZING_RESULTS" in [
+        message.step_value for message in analyst_db.updates
+    ]
+
+
+def test_run_complete_analysis_outer_exception_uses_friendly_llm_error(
+    monkeypatch,
+) -> None:
+    asyncio.run(
+        _assert_run_complete_analysis_outer_exception_uses_friendly_llm_error(
+            monkeypatch
+        )
+    )
+
+
+async def _assert_run_complete_analysis_outer_exception_uses_friendly_llm_error(
+    monkeypatch,
+) -> None:
+    class FakeAnalystDB:
+        def __init__(self) -> None:
+            self.user_message = AnalystChatMessage(
+                id="user-1",
+                role="user",
+                content="sum amount",
+                components=[],
+                in_progress=True,
+            )
+            self.updates: list[AnalystChatMessage] = []
+
+        async def get_chat_message(self, message_id: str) -> AnalystChatMessage | None:
+            if message_id == "user-1":
+                return self.user_message
+            return None
+
+        async def add_chat_message(
+            self, chat_id: str, message: AnalystChatMessage
+        ) -> str:
+            message.id = "assistant-1"
+            return message.id
+
+        async def update_chat_message(
+            self, message_id: str, message: AnalystChatMessage
+        ) -> None:
+            self.updates.append(message.model_copy(deep=True))
+
+    async def fake_rephrase_message(*args, **kwargs) -> str:
+        return "enhanced question"
+
+    async def fake_run_analysis(*args, **kwargs) -> RunAnalysisResult:
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(api, "rephrase_message", fake_rephrase_message)
+    monkeypatch.setattr(api, "run_analysis", fake_run_analysis)
+
+    analyst_db = FakeAnalystDB()
+    results = [
+        component
+        async for component in api.run_complete_analysis(
+            chat_request=ChatRequest(
+                messages=[{"role": "user", "content": "sum amount"}]
+            ),
+            data_source=InternalDataSourceType.FILE,
+            dataset_metadata=[_dataset_metadata("sales")],
+            analyst_db=analyst_db,  # type: ignore[arg-type]
+            chat_id="chat-1",
+            message_id="user-1",
+            request=None,
+            enable_chart_generation=False,
+            enable_business_insights=False,
+        )
+    ]
+
+    error = next(
+        result for result in results if isinstance(result, api.AnalysisGenerationError)
+    )
+    assert error.message == (
+        "Error running initial analysis. Try rephrasing: "
+        "The LLM service did not respond in time. Please try again."
+    )
+    assert analyst_db.updates[-1].error == error.message
+
+
 @pytest.mark.parametrize(
     "case_name",
     ["database", "external_data_store", "remote_registry"],
@@ -660,3 +852,65 @@ async def _assert_run_database_analysis_passes_generator_context_without_argumen
         "token_tracker": token_tracker,
         "telemetry_json": telemetry_json,
     }
+
+
+def test_run_database_analysis_updates_steps_with_analysis_context(
+    monkeypatch,
+) -> None:
+    asyncio.run(_assert_run_database_analysis_updates_steps_with_analysis_context(monkeypatch))
+
+
+async def _assert_run_database_analysis_updates_steps_with_analysis_context(
+    monkeypatch,
+) -> None:
+    class FakeAnalystDB:
+        def __init__(self) -> None:
+            self.updates: list[AnalystChatMessage] = []
+
+        async def update_chat_message(
+            self, message_id: str, message: AnalystChatMessage
+        ) -> None:
+            assert message_id == "assistant-1"
+            self.updates.append(message.model_copy(deep=True))
+
+    class FakeDatabase:
+        async def execute_query(self, query: str) -> list[dict[str, int]]:
+            assert query == "select 300 as total_amount"
+            return [{"total_amount": 300}]
+
+    async def fake_generate_database_analysis_code(
+        database: FakeDatabase,
+        request: api.RunDatabaseAnalysisRequest,
+        analyst_db: FakeAnalystDB,
+        validation_error: object | None = None,
+        token_tracker: TokenUsageTracker | None = None,
+        telemetry_json: dict[str, Any] | None = None,
+    ) -> str:
+        return "select 300 as total_amount"
+
+    monkeypatch.setattr(
+        api,
+        "_generate_database_analysis_code",
+        fake_generate_database_analysis_code,
+    )
+
+    analyst_db = FakeAnalystDB()
+    context = _analysis_context(analyst_db)
+
+    result = await api.run_database_analysis(
+        request=api.RunDatabaseAnalysisRequest(
+            dataset_names=["PUBLIC.sales"],
+            question="sum amount",
+        ),
+        analyst_db=analyst_db,  # type: ignore[arg-type]
+        database_override=FakeDatabase(),  # type: ignore[arg-type]
+        analysis_context=context,
+    )
+
+    await context.await_message_update()
+
+    assert result.status == "success"
+    assert [message.step_value for message in analyst_db.updates] == [
+        "GENERATING_QUERY",
+        "RUNNING_QUERY",
+    ]

--- a/app_backend/tests/test_base_telemetry.py
+++ b/app_backend/tests/test_base_telemetry.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 from core.base_telemetry import BaseTelemetry
+from core.telemetry import OTel
 from opentelemetry import context as otel_context
 
 
@@ -46,6 +47,36 @@ def test_trace_async_generator_close_does_not_detach_in_different_context(
     caplog,
 ) -> None:
     telemetry = BaseTelemetry()
+    monkeypatch.setattr(
+        telemetry,
+        "get_tracer",
+        lambda _name: _ContextAttachingTracer(),
+    )
+
+    @telemetry.trace
+    async def stream_values():
+        yield "first"
+        yield "second"
+
+    async def run() -> None:
+        stream = stream_values()
+        assert await _run_in_context(contextvars.Context(), stream.__anext__()) == (
+            "first"
+        )
+
+        with caplog.at_level(logging.ERROR, logger="opentelemetry.context"):
+            await _run_in_context(contextvars.Context(), stream.aclose())
+
+    asyncio.run(run())
+
+    assert "Failed to detach context" not in caplog.text
+
+
+def test_otel_trace_async_generator_close_does_not_detach_in_different_context(
+    monkeypatch,
+    caplog,
+) -> None:
+    telemetry = OTel()
     monkeypatch.setattr(
         telemetry,
         "get_tracer",

--- a/app_backend/tests/test_schema_pandas_compat.py
+++ b/app_backend/tests/test_schema_pandas_compat.py
@@ -1,5 +1,16 @@
+import asyncio
+import io
+from datetime import datetime, timezone
+
 import pandas as pd
-from utils.schema import DataDictionary
+from openpyxl import load_workbook
+from utils.analyst_db import DatasetMetadata, DatasetType, InternalDataSourceType
+from utils.schema import (
+    AnalystChatMessage,
+    DataDictionary,
+    RunAnalysisResult,
+    RunAnalysisResultMetadata,
+)
 
 
 def test_data_dictionary_from_analyst_df_stringifies_tuple_columns() -> None:
@@ -23,3 +34,111 @@ def test_data_dictionary_from_analyst_df_stringifies_tuple_columns() -> None:
         "int64",
         "int64",
     ]
+
+
+def test_analysis_result_download_uses_pandas_csv_writer() -> None:
+    asyncio.run(_assert_analysis_result_download_uses_pandas_csv_writer())
+
+
+async def _assert_analysis_result_download_uses_pandas_csv_writer() -> None:
+    from core.routers.datasets import download_dataset
+
+    analyst_db = _FakeAnalystDB()
+
+    response = await download_dataset(
+        dataset_id="dataset-123456789",
+        analyst_db=analyst_db,  # type: ignore[arg-type]
+        bom=True,
+    )
+
+    csv_text = response.body.decode("utf-8")
+    assert csv_text == "\ufeffamount,label\n10,A\n20,B\n"
+
+
+def test_chat_excel_export_writes_pandas_analysis_result_sheet() -> None:
+    asyncio.run(_assert_chat_excel_export_writes_pandas_analysis_result_sheet())
+
+
+async def _assert_chat_excel_export_writes_pandas_analysis_result_sheet() -> None:
+    from core.routers.chats import save_chat_messages
+
+    analyst_db = _FakeAnalystDB()
+
+    response = await save_chat_messages(
+        request=None,  # type: ignore[arg-type]
+        chat_id="chat-1",
+        analyst_db=analyst_db,  # type: ignore[arg-type]
+    )
+    chunks: list[bytes] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk if isinstance(chunk, bytes) else chunk.encode("utf-8"))
+    body = b"".join(chunks)
+    workbook = load_workbook(io.BytesIO(body), read_only=True)
+
+    assert "Data" in workbook.sheetnames
+    data_sheet = workbook["Data"]
+    assert data_sheet["A1"].value == "amount"
+    assert data_sheet["B1"].value == "label"
+    assert data_sheet["A2"].value == 10
+    assert data_sheet["B2"].value == "A"
+
+
+class _FakeDatasetHandler:
+    async def get_dataframe(
+        self,
+        dataset_id: str,
+        expected_type: DatasetType,
+        max_rows: int | None = None,
+    ) -> pd.DataFrame:
+        assert dataset_id == "dataset-123456789"
+        assert expected_type is DatasetType.ANALYST_RESULT_DATASET
+        assert max_rows is None
+        return pd.DataFrame({"amount": [10, 20], "label": ["A", "B"]})
+
+    async def get_dataset_metadata(self, dataset_id: str) -> DatasetMetadata:
+        assert dataset_id == "dataset-123456789"
+        return DatasetMetadata(
+            name=dataset_id,
+            external_id=dataset_id,
+            dataset_type=DatasetType.ANALYST_RESULT_DATASET,
+            original_name="analysis_result",
+            created_at=datetime(2026, 6, 28, tzinfo=timezone.utc),
+            columns=["amount", "label"],
+            original_column_types=None,
+            row_count=2,
+            data_source=InternalDataSourceType.GENERATED,
+        )
+
+
+class _FakeAnalystDB:
+    def __init__(self) -> None:
+        self.dataset_handler = _FakeDatasetHandler()
+
+    async def get_chat_messages(self, chat_id: str) -> list[AnalystChatMessage]:
+        assert chat_id == "chat-1"
+        return [
+            AnalystChatMessage(
+                id="user-1",
+                role="user",
+                content="sum amount",
+                components=[],
+                in_progress=False,
+            ),
+            AnalystChatMessage(
+                id="assistant-1",
+                role="assistant",
+                content="analysis",
+                components=[
+                    RunAnalysisResult(
+                        status="success",
+                        dataset_id="dataset-123456789",
+                        metadata=RunAnalysisResultMetadata(
+                            duration=0,
+                            attempts=1,
+                            datasets_analyzed=1,
+                        ),
+                    )
+                ],
+                in_progress=False,
+            ),
+        ]

--- a/core/src/core/analyst_db.py
+++ b/core/src/core/analyst_db.py
@@ -611,12 +611,12 @@ class DatasetHandler(BaseDuckDBHandler):
         if non_null.empty:
             return False
 
-        has_bool = non_null.map(
-            lambda value: isinstance(value, (bool, np.bool_))
-        ).any()
+        has_bool = non_null.map(lambda value: isinstance(value, (bool, np.bool_))).any()
         has_non_bool_number = non_null.map(
-            lambda value: isinstance(value, numbers.Number)
-            and not isinstance(value, (bool, np.bool_))
+            lambda value: (
+                isinstance(value, numbers.Number)
+                and not isinstance(value, (bool, np.bool_))
+            )
         ).any()
         if has_bool and has_non_bool_number:
             return True

--- a/core/src/core/analyst_db.py
+++ b/core/src/core/analyst_db.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import numbers
 import os
 import re
 import uuid
@@ -36,7 +37,7 @@ from typing import (
 
 import aiologic
 import duckdb
-import langid
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 from anyio import Path as AsyncPath
@@ -502,7 +503,7 @@ class DatasetHandler(BaseDuckDBHandler):
         clobber: bool = False,
     ) -> None:
         """
-        Register a Polars DataFrame with explicit dataset type tracking.
+        Register a pandas DataFrame with explicit dataset type tracking.
 
         Args:
             df: The dataframe to register
@@ -528,7 +529,11 @@ class DatasetHandler(BaseDuckDBHandler):
 
         async with self._write_connection() as conn:
             # Create the table
-            arrow_table = pa.Table.from_pandas(df, preserve_index=False)
+            arrow_ready_df = self._normalize_dataframe_for_arrow(df)
+            arrow_table = pa.Table.from_pandas(
+                arrow_ready_df,
+                preserve_index=False,
+            )
 
             def create_table() -> None:
                 conn.register("temp_view", arrow_table)
@@ -584,6 +589,43 @@ class DatasetHandler(BaseDuckDBHandler):
                     metadata.original_column_types,
                 ],
             )
+
+    def _normalize_dataframe_for_arrow(self, df: pd.DataFrame) -> pd.DataFrame:
+        normalized_df: pd.DataFrame | None = None
+
+        for column in df.columns:
+            series = df[column]
+            if not pd.api.types.is_object_dtype(series.dtype):
+                continue
+
+            if self._object_column_needs_string_fallback(series):
+                if normalized_df is None:
+                    normalized_df = df.copy(deep=False)
+                normalized_df[column] = series.astype("string")
+
+        return df if normalized_df is None else normalized_df
+
+    @staticmethod
+    def _object_column_needs_string_fallback(series: pd.Series) -> bool:
+        non_null = series.dropna()
+        if non_null.empty:
+            return False
+
+        has_bool = non_null.map(
+            lambda value: isinstance(value, (bool, np.bool_))
+        ).any()
+        has_non_bool_number = non_null.map(
+            lambda value: isinstance(value, numbers.Number)
+            and not isinstance(value, (bool, np.bool_))
+        ).any()
+        if has_bool and has_non_bool_number:
+            return True
+
+        try:
+            pa.array(series, from_pandas=True)
+        except (pa.ArrowInvalid, pa.ArrowTypeError):
+            return True
+        return False
 
     async def list_datasets(
         self,
@@ -2113,98 +2155,6 @@ class AnalystDB:
         await self.chat_handler._initialize_database()
         await self.user_recipe_handler._initialize_database()
         await self.data_source_handler._initialize_database()
-
-    async def _validate_and_fix_dtypes(self, df, dataset_name: str):
-        # MODIFY POINT
-        """Validate and fix dtypes for the given dataframe.
-
-        Converts object columns to numeric if possible, otherwise to string.
-        Logs warnings for columns that cannot be converted to numeric.
-
-        Args:
-            df: Input dataframe to validate and fix dtypes
-            dataset_name: Name of the dataset for logging purposes
-
-        Returns:
-            pd.DataFrame: The fixed dataframe with validated dtypes
-        """
-        dataset_df = df.to_df() if hasattr(df, "to_df") else df
-        failed_columns = []
-        for col in dataset_df.columns:
-            if dataset_df[col].dtype == object:
-                converted = pd.to_numeric(dataset_df[col], errors="coerce")
-                mask = (~dataset_df[col].isnull()) & (converted.isnull())
-                if mask.any():
-                    sample_vals = dataset_df[col][mask].astype(str).unique()[:5]
-                    failed_columns.append(
-                        {
-                            "column": col,
-                            "original_dtype": str(dataset_df[col].dtype),
-                            "sample_problematic_values": sample_vals.tolist(),
-                        }
-                    )
-                    dataset_df[col] = dataset_df[col].astype(str)
-                else:
-                    dataset_df[col] = converted
-        if failed_columns:
-            error_msg = (
-                f"Conversion failed for dataset '{dataset_name}'. "
-                f"The following columns could not be converted to numeric types:\n"
-            )
-            for col_info in failed_columns:
-                error_msg += (
-                    f"- Column: {col_info['column']} (dtype: {col_info['original_dtype']})\n"
-                    f"  Problematic values: {col_info['sample_problematic_values']}\n"
-                )
-            logger.warning(error_msg)
-        return dataset_df
-
-    async def _is_text_column(self, series: pd.Series) -> bool:
-        """
-        Detect if a column is a text column using language detection and heuristics.
-        Returns True if the column is considered text, False otherwise.
-        """
-        # Drop NA and convert to string
-        lines = series.dropna().astype(str)
-        if len(lines) == 0:
-            return False
-        # Detect language on a sample of lines
-        sample_lines = lines.sample(min(20, len(lines)), random_state=42)
-        lang_counts = {}
-        for line in sample_lines:
-            lang, _ = langid.classify(line)
-            lang_counts[lang] = lang_counts.get(lang, 0) + 1
-        if not lang_counts:
-            return False
-        detected_lang = max(lang_counts, key=lang_counts.get)
-        # Heuristics
-        n_lines = len(lines)
-        n_unique = lines.nunique()
-        unique_ratio = n_unique / n_lines
-        mean_len = lines.str.len().mean()
-        longest_line = lines.str.len().max()
-        # For percentiles
-        pct_7_chars = (lines.str.len() >= 7).mean()
-        # For word-based stats
-        mean_spaces = lines.str.count(r" ").mean()
-        pct_4_words = (lines.str.split().apply(len) >= 4).mean()
-        longest_words = lines.str.split().apply(len).max()
-        # For CJK
-        if detected_lang in {"ja", "zh", "ko"}:
-            criteria = [
-                unique_ratio > 0.3 or n_unique > 1000,
-                mean_len >= 4,
-                pct_7_chars >= 0.1,
-                longest_line >= 12,
-            ]
-        else:
-            criteria = [
-                unique_ratio > 0.3 or n_unique > 1000,
-                mean_spaces >= 1.5,
-                pct_4_words >= 0.1,
-                longest_words >= 6,
-            ]
-        return sum(criteria) >= 3
 
     async def register_dataset(
         self,

--- a/core/src/core/api.py
+++ b/core/src/core/api.py
@@ -2453,7 +2453,9 @@ async def run_complete_analysis(
         analysis_context.stage_message_update()
 
     except Exception as e:
-        error_message = f"Error setting up additional analysis: {_friendly_llm_error(e)}"
+        error_message = (
+            f"Error setting up additional analysis: {_friendly_llm_error(e)}"
+        )
         assistant_message.in_progress = False
         assistant_message.error = error_message
         analysis_context.stage_message_update()

--- a/core/src/core/api.py
+++ b/core/src/core/api.py
@@ -1907,13 +1907,22 @@ async def _generate_database_analysis_code(
 @telemetry.trace
 async def _run_database_analysis(
     request: RunDatabaseAnalysisRequest,
-    analyst_db: AnalystDB,
+    analyst_db: AnalystDB | None = None,
     database_override: DatabaseOperator[Any] | None = None,
     exception_history: list[InvalidGeneratedCode] | None = None,
     token_tracker: TokenUsageTracker | None = None,
     telemetry_json: dict[str, Any] | None = None,
+    analysis_context: RunCompleteAnalysisRequestContext | None = None,
 ) -> RunDatabaseAnalysisResult:
     start_time = datetime.now()
+    if analysis_context:
+        analyst_db = analysis_context.analyst_db
+        token_tracker = analysis_context.token_tracker
+        database_override = database_override or analysis_context.database
+
+    if analyst_db is None:
+        raise ValueError("analyst_db is required")
+
     if not request.dataset_names:
         raise ValueError(VALUE_ERROR_MESSAGE)
 
@@ -1924,6 +1933,15 @@ async def _run_database_analysis(
         get_external_database() if database_override is None else database_override
     )
 
+    if (
+        analysis_context
+        and analysis_context.assistant_message_id
+        and analysis_context.assistant_message
+    ):
+        analysis_context.assistant_message.step_value = "GENERATING_QUERY"
+        analysis_context.assistant_message.step_reattempt = len(exception_history)
+        analysis_context.stage_message_update()
+
     sql_code = await _generate_database_analysis_code(
         database,
         request,
@@ -1932,6 +1950,15 @@ async def _run_database_analysis(
         token_tracker,
         telemetry_json=telemetry_json,
     )
+    if (
+        analysis_context
+        and analysis_context.assistant_message_id
+        and analysis_context.assistant_message
+    ):
+        analysis_context.assistant_message.step_value = "RUNNING_QUERY"
+        analysis_context.assistant_message.step_reattempt = len(exception_history)
+        analysis_context.stage_message_update()
+
     try:
         results = await database.execute_query(query=sql_code)
         results = cast(list[dict[str, Any]], results)
@@ -1960,10 +1987,11 @@ async def _run_database_analysis(
 @telemetry.meter_and_trace
 async def run_database_analysis(
     request: RunDatabaseAnalysisRequest,
-    analyst_db: AnalystDB,
+    analyst_db: AnalystDB | None = None,
     database_override: DatabaseOperator[Any] | None = None,
     token_tracker: TokenUsageTracker | None = None,
-    telemetry_json: dict[str, Any] = None,
+    telemetry_json: dict[str, Any] | None = None,
+    analysis_context: RunCompleteAnalysisRequestContext | None = None,
 ) -> RunDatabaseAnalysisResult:
     """Execute analysis workflow on datasets."""
     try:
@@ -1973,6 +2001,7 @@ async def run_database_analysis(
             database_override=database_override,
             token_tracker=token_tracker,
             telemetry_json=telemetry_json,
+            analysis_context=analysis_context,
         )
     except MaxReflectionAttempts as e:
         return RunDatabaseAnalysisResult(
@@ -2160,12 +2189,12 @@ async def run_complete_analysis(
 
     except Exception as e:
         logger.error(f"Error rephrasing message: {e}", exc_info=True)
-        user_message.error = f"Failed to process your question: {str(e)}"
-        user_message.in_progress = False
-        await analyst_db.update_chat_message(
-            message_id=message_id,
-            message=user_message,
+        user_message.error = (
+            f"Failed to process your question: {_friendly_llm_error(e)}"
         )
+        user_message.in_progress = False
+        analysis_context.stage_message_update(target="user")
+        await analysis_context.await_message_update()
         yield AnalysisGenerationError(user_message.error)
 
         return
@@ -2190,12 +2219,10 @@ async def run_complete_analysis(
         chat_id=chat_id,
         message=assistant_message,
     )
+    analysis_context.stage_message_update()
 
     user_message.in_progress = False
-    await analyst_db.update_chat_message(
-        message_id=message_id,
-        message=user_message,
-    )
+    analysis_context.stage_message_update(target="user")
     # Run main analysis
     logger.info("Start main analysis")
     try:
@@ -2217,6 +2244,7 @@ async def run_complete_analysis(
                 analyst_db,
                 token_tracker=token_tracker,
                 telemetry_json=telemetry_json,
+                analysis_context=analysis_context,
             )
         elif isinstance(data_source, ExternalDataStoreNameDataSourceType):
             logger.info("Running DataStore DataWrangling analysis")
@@ -2226,11 +2254,10 @@ async def run_complete_analysis(
             if not data_store_id:
                 assistant_message.in_progress = False
                 assistant_message.error = "A remote dataset was deleted and can no longer be used for analysis. Please refresh."
-                await analyst_db.update_chat_message(
-                    assistant_message.id, assistant_message
-                )
+                analysis_context.stage_message_update()
 
                 yield AnalysisGenerationError(assistant_message.error)
+                await analysis_context.await_message_update()
                 return
 
             if request:
@@ -2247,11 +2274,10 @@ async def run_complete_analysis(
             if result:
                 assistant_message.in_progress = False
                 assistant_message.error = "A remote dataset was deleted and can no longer be used for analysis. Please refresh."
-                await analyst_db.update_chat_message(
-                    assistant_message.id, assistant_message
-                )
+                analysis_context.stage_message_update()
 
                 yield AnalysisGenerationError(assistant_message.error)
+                await analysis_context.await_message_update()
                 return
 
             logger.debug(
@@ -2271,6 +2297,7 @@ async def run_complete_analysis(
                 database_override=recipe.as_database_operator(),
                 token_tracker=token_tracker,
                 telemetry_json=telemetry_json,
+                analysis_context=analysis_context,
             )
 
         else:
@@ -2294,11 +2321,10 @@ async def run_complete_analysis(
                 if refresh:
                     assistant_message.in_progress = False
                     assistant_message.error = "A remote dataset was deleted and can no longer be used for analysis. Please refresh."
-                    await analyst_db.update_chat_message(
-                        assistant_message.id, assistant_message
-                    )
+                    analysis_context.stage_message_update()
 
                     yield AnalysisGenerationError(assistant_message.error)
+                    await analysis_context.await_message_update()
 
                     return
 
@@ -2311,6 +2337,7 @@ async def run_complete_analysis(
                     database_override=recipe.as_database_operator(),
                     token_tracker=token_tracker,
                     telemetry_json=telemetry_json,
+                    analysis_context=analysis_context,
                 )
             elif all(m.external_id is None for m in dataset_metadata):
                 logging.info("Running local analysis")
@@ -2333,39 +2360,43 @@ async def run_complete_analysis(
         logger.info("Getting analysis result done")
 
         if isinstance(analysis_result, BaseException):
-            error_message = f"Error running initial analysis. Try rephrasing: {str(analysis_result)}"
+            error_message = (
+                "Error running initial analysis. Try rephrasing: "
+                f"{_friendly_llm_error(analysis_result)}"
+            )
             assistant_message.in_progress = False
             assistant_message.error = error_message
-            await analyst_db.update_chat_message(
-                message_id=assistant_message.id, message=assistant_message
-            )
+            analysis_context.stage_message_update()
 
             yield AnalysisGenerationError(error_message)
 
+            await analysis_context.await_message_update()
             return
 
         yield analysis_result
 
         assistant_message.components.append(analysis_result)
+        assistant_message.step_value = "ANALYZING_RESULTS"
+        analysis_context.stage_message_update()
 
         assistant_message = await extract_and_store_datasets(
             analyst_db, assistant_message
         )
+        analysis_context.assistant_message = assistant_message
 
-        await analyst_db.update_chat_message(
-            message_id=assistant_message.id, message=assistant_message
-        )
+        analysis_context.stage_message_update()
 
     except Exception as e:
-        error_message = f"Error running initial analysis. Try rephrasing: {str(e)}"
+        error_message = (
+            f"Error running initial analysis. Try rephrasing: {_friendly_llm_error(e)}"
+        )
         assistant_message.in_progress = False
         assistant_message.error = error_message
-        await analyst_db.update_chat_message(
-            message_id=assistant_message.id, message=assistant_message
-        )
+        analysis_context.stage_message_update()
 
         yield AnalysisGenerationError(error_message)
 
+        await analysis_context.await_message_update()
         return
 
     # Only proceed with additional analysis if we have valid initial results
@@ -2375,9 +2406,8 @@ async def run_complete_analysis(
         and (enable_chart_generation or enable_business_insights)
     ):
         assistant_message.in_progress = False
-        await analyst_db.update_chat_message(
-            message_id=assistant_message.id, message=assistant_message
-        )
+        analysis_context.stage_message_update()
+        await analysis_context.await_message_update()
         return
 
     # Run concurrent analyses
@@ -2395,17 +2425,13 @@ async def run_complete_analysis(
         if isinstance(charts_result, BaseException):
             error_message = "Error generating charts"
             assistant_message.error = error_message
-            await analyst_db.update_chat_message(
-                message_id=assistant_message.id, message=assistant_message
-            )
+            analysis_context.stage_message_update()
 
             yield AnalysisGenerationError(error_message)
 
         elif charts_result is not None:
             assistant_message.components.append(charts_result)
-            await analyst_db.update_chat_message(
-                message_id=assistant_message.id, message=assistant_message
-            )
+            analysis_context.stage_message_update()
 
             yield charts_result
 
@@ -2413,33 +2439,24 @@ async def run_complete_analysis(
         if isinstance(business_result, BaseException):
             error_message = "Error generating business insights"
             assistant_message.error = error_message
-            await analyst_db.update_chat_message(
-                message_id=assistant_message.id, message=assistant_message
-            )
+            analysis_context.stage_message_update()
 
             yield AnalysisGenerationError(error_message)
 
         elif business_result is not None:
             assistant_message.components.append(business_result)
-            await analyst_db.update_chat_message(
-                message_id=assistant_message.id, message=assistant_message
-            )
+            analysis_context.stage_message_update()
 
             yield business_result
 
         assistant_message.in_progress = False
-        await analyst_db.update_chat_message(
-            message_id=assistant_message.id, message=assistant_message
-        )
-        yield business_result
+        analysis_context.stage_message_update()
 
     except Exception as e:
-        error_message = f"Error setting up additional analysis: {str(e)}"
+        error_message = f"Error setting up additional analysis: {_friendly_llm_error(e)}"
         assistant_message.in_progress = False
         assistant_message.error = error_message
-        await analyst_db.update_chat_message(
-            message_id=assistant_message.id, message=assistant_message
-        )
+        analysis_context.stage_message_update()
 
         yield AnalysisGenerationError(error_message)
 
@@ -2452,11 +2469,11 @@ async def run_complete_analysis(
 
             assistant_message.components.append(final_usage_component)
 
-            await analyst_db.update_chat_message(
-                message_id=assistant_message.id, message=assistant_message
-            )
+            analysis_context.stage_message_update()
 
             yield final_usage_component
+
+        await analysis_context.await_message_update()
 
 
 async def process_data_and_update_state(

--- a/core/src/core/routers/chats.py
+++ b/core/src/core/routers/chats.py
@@ -23,7 +23,6 @@ import tempfile
 from typing import Any, List, Union, cast
 
 import pandas as pd
-import polars.dataframe.frame
 from datarobot_genai.core.utils.token_tracking import (
     HeuristicTokenCountingStrategy,
     TokenUsageTracker,
@@ -707,12 +706,7 @@ async def save_chat_messages(
                 data_sheet = analysis_workbook.create_sheet(data_sheet_name)
 
                 try:
-                    dataset: polars.dataframe.frame.DataFrame = (
-                        dataset_to_export.data.df
-                    )
-
-                    # Convert to pandas with error handling for large datasets
-                    pandas_df = dataset.to_pandas()
+                    pandas_df = dataset_to_export.to_df()
 
                     # Add size check to prevent memory issues and Excel limits
                     original_rows = pandas_df.shape[0]

--- a/core/src/core/routers/datasets.py
+++ b/core/src/core/routers/datasets.py
@@ -320,7 +320,7 @@ async def download_dataset(
         )
 
         csv_content = io.StringIO()
-        df.write_csv(csv_content)
+        df.to_csv(csv_content, index=False)
 
         csv_text = csv_content.getvalue()
         if bom:

--- a/core/src/core/telemetry/otel.py
+++ b/core/src/core/telemetry/otel.py
@@ -26,7 +26,7 @@ import inspect
 import logging
 import os
 import time
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -583,9 +583,21 @@ class OTel:
 
             @functools.wraps(func)
             async def inner_asyncgen(*args, **kwargs):
-                with tracer.start_as_current_span(span_name):
-                    async for x in func(*args, **kwargs):
+                span = tracer.start_span(span_name)
+                async_generator = func(*args, **kwargs)
+                try:
+                    while True:
+                        try:
+                            with trace.use_span(span, end_on_exit=False):
+                                x = await async_generator.__anext__()
+                        except StopAsyncIteration:
+                            break
                         yield x
+                finally:
+                    with suppress(Exception):
+                        with trace.use_span(span, end_on_exit=False):
+                            await async_generator.aclose()
+                    span.end()
 
             return inner_asyncgen
         elif inspect.isgeneratorfunction(func):

--- a/customize_docs/upstream_aligned_stability_20260628.md
+++ b/customize_docs/upstream_aligned_stability_20260628.md
@@ -1,0 +1,52 @@
+# Upstream-Aligned Stability 2026-06-28
+
+## 背景
+
+`main(v0.3.5)` や upstream/main v11.8.2 に比べて、pandas 版 fork で初期分析が失敗しやすくなっていた。
+代表例は analyst result 登録時に `最小値=[1.0, np.False_, 3.2]` のような mixed `object` 列を `pyarrow.Table.from_pandas()` に渡し、Arrow が数値列へ変換しようとして失敗するケース。
+
+upstream は Polars DataFrame の `to_arrow()` で登録しているが、この fork では公開境界を pandas のまま維持する。Polars 移行は行わない。
+
+## 方針
+
+- pandas DataFrame を DuckDB/Arrow に登録する直前だけ正規化する。
+- 通常の数値、bool、datetime、文字列列は維持する。
+- Arrow 変換できない mixed `object` 列、または数値と `bool` / `np.bool_` が混在する `object` 列だけ `string` 化する。
+- `run_complete_analysis` は upstream の `RunCompleteAnalysisRequestContext` に寄せ、`stage_message_update()` / `await_message_update()` を使う。
+- 外部 Data Store / remote registry は fork 機能として残す。
+- database analysis にも `GENERATING_QUERY` / `RUNNING_QUERY` step 更新を入れる。
+- outer exception は raw `str(e)` ではなく `_friendly_llm_error(e)` を使う。
+- analyst result の CSV download / Excel export は pandas DataFrame 前提に戻す。
+- `core.telemetry.OTel.trace` の async generator close 時に別 context の detach error を出さない。
+
+## テスト
+
+追加した主な回帰テスト:
+
+- `最小値=[1.0, np.False_, 3.2]` を含む analysis result が保存・取得できること。
+- analyst result の CSV download と Excel export が pandas DataFrame で成功すること。
+- `run_complete_analysis` が `ANALYZING_RESULTS` を staged update し、business result を重複 yield しないこと。
+- database analysis が context 経由で `GENERATING_QUERY` / `RUNNING_QUERY` を更新すること。
+- 初期分析の outer exception が `_friendly_llm_error()` の文言になること。
+- `core.telemetry.OTel.trace` の async generator close で `Failed to detach context` が出ないこと。
+
+実行結果:
+
+```text
+uv run pytest app_backend/tests/test_llm_client.py -q
+12 passed, 3 warnings
+
+uv run pytest app_backend/tests/test_analyst_db_upstream_compat.py app_backend/tests/test_schema_pandas_compat.py -q
+11 passed
+
+uv run pytest app_backend/tests/test_base_telemetry.py app_backend/tests/test_api_analysis_execution_v0424_compat.py -q
+16 passed
+
+uv run pytest app_backend/tests/test_v1182_compat.py app_backend/tests/test_v1172_compat.py -q
+18 passed
+
+uv run ruff check core/src/core/analyst_db.py core/src/core/api.py core/src/core/routers/chats.py core/src/core/routers/datasets.py core/src/core/telemetry/otel.py app_backend/tests/test_analyst_db_upstream_compat.py app_backend/tests/test_schema_pandas_compat.py app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_base_telemetry.py
+All checks passed
+```
+
+`test_llm_client.py` では LiteLLM の atexit logging / cleanup warning が出るが、テスト結果は成功。


### PR DESCRIPTION
## Scope

- Stabilize pandas-backed analyst result persistence while staying aligned with upstream v11.8.2 flow.
- Keep the public dataframe boundary as pandas; this PR does not migrate pandas paths to Polars.
- Restore upstream-style staged chat message updates in `run_complete_analysis` and database analysis steps.
- Fix analyst result CSV download and Excel export to work with pandas DataFrames.
- Prevent `core.telemetry.OTel.trace` async generator close from logging context detach errors.

## Root Cause

The pandas fork registers analyst result datasets via `pyarrow.Table.from_pandas()`. Mixed `object` columns such as `最小値=[1.0, np.False_, 3.2]` can make Arrow infer a numeric conversion path and then fail with `Could not convert np.False_ ... tried to convert to double`.

There were also remaining upstream drift points: direct message updates instead of staged updates, missing database step updates, raw `str(e)` user-facing errors, a duplicate business result yield, and Polars-only assumptions in analyst result export paths.

## What Changed

- Normalize pandas DataFrames only immediately before Arrow registration.
- Convert only unsafe mixed `object` columns or numeric/bool mixed `object` columns to pandas `string`; preserve normal numeric, bool, datetime, and string columns.
- Remove unused broad dtype/text helpers from the previous customization.
- Pass `RunCompleteAnalysisRequestContext` through database analysis and stage `GENERATING_QUERY` / `RUNNING_QUERY` updates.
- Restore `ANALYZING_RESULTS` before storing result datasets.
- Use `_friendly_llm_error()` for outer initial/additional analysis exceptions.
- Remove duplicate `business_result` yield.
- Use pandas `to_csv(index=False)` and `dataframe_to_rows()` directly for analyst result export.
- Align `OTel.trace` async generator handling with the safer base telemetry implementation.

## Validation

```text
uv run pytest app_backend/tests/test_llm_client.py -q
12 passed, 3 warnings

uv run pytest app_backend/tests/test_analyst_db_upstream_compat.py app_backend/tests/test_schema_pandas_compat.py -q
11 passed

uv run pytest app_backend/tests/test_base_telemetry.py app_backend/tests/test_api_analysis_execution_v0424_compat.py -q
16 passed

uv run pytest app_backend/tests/test_v1182_compat.py app_backend/tests/test_v1172_compat.py -q
18 passed

uv run ruff check core/src/core/analyst_db.py core/src/core/api.py core/src/core/routers/chats.py core/src/core/routers/datasets.py core/src/core/telemetry/otel.py app_backend/tests/test_analyst_db_upstream_compat.py app_backend/tests/test_schema_pandas_compat.py app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_base_telemetry.py
All checks passed!
```

Note: `test_llm_client.py` still emits existing LiteLLM atexit logging/cleanup warnings after pytest success.
