### PR TITLE
[codex] Align LLM wrapper with upstream timeouts

### DIFF
--- a/app_backend/tests/test_llm_client.py
+++ b/app_backend/tests/test_llm_client.py
@@ -113,7 +113,7 @@ def test_completions_proxy_tracks_tokens_for_create_with_completion() -> None:
     assert completions.kwargs is not None
     assert completions.kwargs["timeout"] == 12
     assert completions.kwargs["max_completion_tokens"] == 128
-    assert tracker.calls == [(messages, "created", "model")]
+    assert tracker.calls == [(messages, "raw", "model")]
 
 
 def test_completions_proxy_logs_verbose_llm_api_errors(
@@ -179,7 +179,7 @@ def test_llm_client_config_prefers_gateway_default_model(
     assert config.should_use_litellm is True
 
 
-def test_async_llm_client_preserves_legacy_openai_timeout(
+def test_async_llm_client_openai_fallback_uses_upstream_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _clear_llm_env(monkeypatch)
@@ -201,14 +201,31 @@ def test_async_llm_client_preserves_legacy_openai_timeout(
         async with AsyncLLMClient(
             dr_client=_FakeDataRobotClient(),
             deployment_base_url="https://example.test/deployments/abc/chat/completions",
+            llm_config=llm_client.LLMClientConfig(),
         ):
             pass
 
     asyncio.run(run_client())
 
-    assert created_clients[0].kwargs["timeout"] == 180
+    assert created_clients[0].kwargs["timeout"] == 900
     assert created_clients[0].kwargs["max_retries"] == 2
     assert created_clients[0].closed is True
+
+
+def test_llm_client_config_uses_upstream_config_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://app.datarobot.example/api/v2")
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "token-123")
+
+    config = llm_client.LLMClientConfig.from_env()
+
+    assert config.default_model == "custom-model"
+    assert config.datarobot_endpoint == "https://app.datarobot.example/api/v2"
+    assert config.datarobot_api_token == "token-123"
+    assert config.timeout == 900
+    assert config.should_use_litellm is True
 
 
 def test_async_llm_client_uses_litellm_gateway_configuration(
@@ -228,6 +245,11 @@ def test_async_llm_client_uses_litellm_gateway_configuration(
         litellm_calls["kwargs"] = kwargs
         return completions.create
 
+    def fake_from_litellm(*args: Any, **kwargs: Any) -> _FakeInstructorClient:
+        litellm_calls["from_litellm_args"] = args
+        litellm_calls["from_litellm_kwargs"] = kwargs
+        return _FakeInstructorClient(completions)
+
     monkeypatch.setattr(
         llm_client,
         "litellm",
@@ -242,7 +264,7 @@ def test_async_llm_client_uses_litellm_gateway_configuration(
     monkeypatch.setattr(
         llm_client.instructor,
         "from_litellm",
-        lambda *_args, **_kwargs: pytest.fail("from_litellm should not be used"),
+        fake_from_litellm,
         raising=False,
     )
     monkeypatch.setattr(
@@ -266,11 +288,16 @@ def test_async_llm_client_uses_litellm_gateway_configuration(
     result = asyncio.run(run_client())
 
     assert result == "created"
+    assert litellm_calls["from_litellm_args"] == (llm_client.litellm.acompletion,)
+    assert (
+        litellm_calls["from_litellm_kwargs"]["mode"]
+        is llm_client.instructor.Mode.MD_JSON
+    )
     assert litellm_calls["completion_fn"] is llm_client.litellm.acompletion
     assert litellm_calls["kwargs"]["mode"] is llm_client.instructor.Mode.MD_JSON
     assert completions.kwargs is not None
     assert completions.kwargs["model"] == "datarobot/bedrock/test-model"
-    assert completions.kwargs["timeout"] == 180
+    assert completions.kwargs["timeout"] == 900
     assert completions.kwargs["max_retries"] == 2
     assert "max_tokens" not in completions.kwargs
     assert completions.kwargs["max_completion_tokens"] == 128
@@ -300,6 +327,11 @@ def test_async_llm_client_litellm_create_with_completion_uses_async_adapter(
         captured["patched_mode"] = kwargs["mode"]
         return fake_create_fn
 
+    def fake_from_litellm(*args: Any, **kwargs: Any) -> _FakeInstructorClient:
+        captured["from_litellm_args"] = args
+        captured["from_litellm_kwargs"] = kwargs
+        return _FakeInstructorClient(_RecordingCompletions())
+
     monkeypatch.setattr(
         llm_client,
         "litellm",
@@ -310,9 +342,7 @@ def test_async_llm_client_litellm_create_with_completion_uses_async_adapter(
     monkeypatch.setattr(
         llm_client.instructor,
         "from_litellm",
-        lambda *_args, **_kwargs: pytest.fail(
-            "from_litellm treats coroutine functions as a sync client in instructor 1.3.4"
-        ),
+        fake_from_litellm,
         raising=False,
     )
 
@@ -331,10 +361,12 @@ def test_async_llm_client_litellm_create_with_completion_uses_async_adapter(
 
     assert response is structured_response
     assert raw is raw_response
+    assert captured["from_litellm_args"] == (llm_client.litellm.acompletion,)
+    assert captured["from_litellm_kwargs"]["mode"] is llm_client.instructor.Mode.MD_JSON
     assert captured["patched_create"] is fake_acompletion
     assert captured["patched_mode"] is llm_client.instructor.Mode.MD_JSON
     assert captured["create_fn_kwargs"]["model"] == "datarobot/bedrock/test-model"
-    assert captured["create_fn_kwargs"]["timeout"] == 180
+    assert captured["create_fn_kwargs"]["timeout"] == 900
     assert captured["create_fn_kwargs"]["max_retries"] == 2
 
 
@@ -369,7 +401,7 @@ def test_async_llm_client_injects_deployed_llm_api_base(
     monkeypatch.setattr(
         llm_client.instructor,
         "from_litellm",
-        lambda *_args, **_kwargs: pytest.fail("from_litellm should not be used"),
+        lambda *_args, **_kwargs: _FakeInstructorClient(_RecordingCompletions()),
         raising=False,
     )
 
@@ -397,7 +429,7 @@ def test_async_llm_client_injects_deployed_llm_api_base(
     assert completions.kwargs["timeout"] == 45
 
 
-def test_async_llm_client_deployed_llm_uses_provider_when_default_model_missing(
+def test_async_llm_client_deployed_llm_uses_config_default_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _clear_llm_env(monkeypatch)
@@ -440,7 +472,7 @@ def test_async_llm_client_deployed_llm_uses_provider_when_default_model_missing(
         "https://app.datarobot.example/api/v2/deployments/"
         "deployment-123/chat/completions"
     )
-    assert completions.kwargs["model"] == "datarobot/datarobot-deployed-llm"
+    assert completions.kwargs["model"] == "datarobot/custom-model"
 
 
 def test_async_llm_client_litellm_exit_does_not_close_shared_async_clients(

--- a/app_backend/tests/test_llm_client.py
+++ b/app_backend/tests/test_llm_client.py
@@ -430,6 +430,7 @@ def test_async_llm_client_deployed_llm_uses_config_default_model(
 ) -> None:
     _clear_llm_env(monkeypatch)
     monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://app.datarobot.example/api/v2")
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "token-123")
     monkeypatch.setenv("TEXTGEN_DEPLOYMENT_ID", "deployment-123")
     completions = _RecordingCompletions()
 

--- a/app_backend/tests/test_llm_client.py
+++ b/app_backend/tests/test_llm_client.py
@@ -11,11 +11,7 @@ import httpx
 import pytest
 from openai import APIConnectionError
 from pydantic import BaseModel
-from utils.llm_client import (
-    AsyncLLMClient,
-    CompletionsProxy,
-    CompletionTokenCompatibilityProxy,
-)
+from utils.llm_client import AsyncLLMClient, CompletionsProxy
 
 from core import llm_client
 
@@ -50,16 +46,6 @@ class _RecordingTracker:
 class _FakeInstructorClient:
     def __init__(self, completions: _RecordingCompletions) -> None:
         self.chat = SimpleNamespace(completions=completions)
-
-
-class _FakeOpenAIClient:
-    def __init__(self, **kwargs: Any) -> None:
-        self.kwargs = kwargs
-        self.chat = SimpleNamespace(completions=_RecordingCompletions())
-        self.closed = False
-
-    async def close(self) -> None:
-        self.closed = True
 
 
 class _FakeDataRobotClient:
@@ -148,18 +134,6 @@ def test_completions_proxy_logs_verbose_llm_api_errors(
     assert "Error: APIConnectionError: network down" in caplog.text
 
 
-def test_completion_token_compatibility_proxy_rewrites_max_tokens() -> None:
-    completions = _RecordingCompletions()
-    proxy = CompletionTokenCompatibilityProxy(completions)
-
-    result = asyncio.run(proxy.create(messages=[], model="model", max_tokens=128))
-
-    assert result == "created"
-    assert completions.kwargs is not None
-    assert "max_tokens" not in completions.kwargs
-    assert completions.kwargs["max_completion_tokens"] == 128
-
-
 def test_llm_client_config_prefers_gateway_default_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -176,40 +150,63 @@ def test_llm_client_config_prefers_gateway_default_model(
     assert config.default_model == (
         "datarobot/bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0"
     )
-    assert config.should_use_litellm is True
 
 
-def test_async_llm_client_openai_fallback_uses_upstream_timeout(
+def test_async_llm_client_always_uses_litellm_even_without_config_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _clear_llm_env(monkeypatch)
-    created_clients: list[_FakeOpenAIClient] = []
+    completions = _RecordingCompletions()
+    captured: dict[str, Any] = {}
 
-    def fake_openai_client(**kwargs: Any) -> _FakeOpenAIClient:
-        client = _FakeOpenAIClient(**kwargs)
-        created_clients.append(client)
-        return client
+    monkeypatch.setattr(
+        llm_client,
+        "litellm",
+        SimpleNamespace(acompletion=lambda **_kwargs: None),
+        raising=False,
+    )
 
-    monkeypatch.setattr(llm_client, "AsyncOpenAI", fake_openai_client)
+    def fake_from_litellm(*args: Any, **kwargs: Any) -> _FakeInstructorClient:
+        captured["from_litellm"] = (args, kwargs)
+        return _FakeInstructorClient(completions)
+
+    monkeypatch.setattr(
+        llm_client.instructor,
+        "AsyncInstructor",
+        _FakeInstructorClient,
+    )
+    monkeypatch.setattr(
+        llm_client.instructor,
+        "from_litellm",
+        fake_from_litellm,
+        raising=False,
+    )
     monkeypatch.setattr(
         llm_client.instructor,
         "from_openai",
-        lambda *_args, **_kwargs: _FakeInstructorClient(_RecordingCompletions()),
+        lambda *_args, **_kwargs: pytest.fail("OpenAI fallback should not be used"),
     )
 
-    async def run_client() -> None:
+    async def run_client() -> str:
         async with AsyncLLMClient(
             dr_client=_FakeDataRobotClient(),
             deployment_base_url="https://example.test/deployments/abc/chat/completions",
             llm_config=llm_client.LLMClientConfig(),
-        ):
-            pass
+        ) as client:
+            return await client.chat.completions.create(
+                messages=[],
+                model="datarobot-deployed-llm",
+                max_tokens=128,
+                response_model=object,
+            )
 
-    asyncio.run(run_client())
+    result = asyncio.run(run_client())
 
-    assert created_clients[0].kwargs["timeout"] == 900
-    assert created_clients[0].kwargs["max_retries"] == 2
-    assert created_clients[0].closed is True
+    assert result == "created"
+    assert "from_litellm" in captured
+    assert completions.kwargs is not None
+    assert completions.kwargs["timeout"] == 900
+    assert completions.kwargs["max_retries"] == 2
 
 
 def test_llm_client_config_uses_upstream_config_defaults(
@@ -225,7 +222,6 @@ def test_llm_client_config_uses_upstream_config_defaults(
     assert config.datarobot_endpoint == "https://app.datarobot.example/api/v2"
     assert config.datarobot_api_token == "token-123"
     assert config.timeout == 900
-    assert config.should_use_litellm is True
 
 
 def test_async_llm_client_uses_litellm_gateway_configuration(

--- a/app_backend/tests/test_llm_upstream_alignment.py
+++ b/app_backend/tests/test_llm_upstream_alignment.py
@@ -1,0 +1,31 @@
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_core_api_create_with_completion_calls_keep_upstream_timeout() -> None:
+    tree = ast.parse((REPO_ROOT / "core/src/core/api.py").read_text())
+    missing_timeout_lines: list[int] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr != "create_with_completion":
+            continue
+
+        timeout_keyword = next(
+            (keyword for keyword in node.keywords if keyword.arg == "timeout"),
+            None,
+        )
+        if not (
+            timeout_keyword is not None
+            and isinstance(timeout_keyword.value, ast.Constant)
+            and timeout_keyword.value.value == 900
+        ):
+            missing_timeout_lines.append(node.lineno)
+
+    assert missing_timeout_lines == []

--- a/core/src/core/api.py
+++ b/core/src/core/api.py
@@ -643,6 +643,7 @@ async def _get_dictionary_batch(
                     response_model=DictionaryGeneration,
                     model=ALTERNATIVE_LLM_SMALL,
                     messages=messages,
+                    timeout=900,
                 )
 
         # Convert to dictionary format
@@ -1003,6 +1004,7 @@ async def _generate_run_charts_python_code(
                 model=ALTERNATIVE_LLM_BIG,
                 temperature=0,
                 messages=messages,
+                timeout=900,
             )
     association_id = response_org.datarobot_moderations["association_id"]
     logger.info(f"Association ID: {association_id}")
@@ -1167,6 +1169,7 @@ async def _generate_run_analysis_python_code(
                 temperature=0.1,
                 messages=messages,
                 max_retries=10,
+                timeout=900,
             )
     association_id = completion_org.datarobot_moderations["association_id"]
     logger.info(f"Association ID: {association_id}")
@@ -1347,6 +1350,7 @@ async def rephrase_message(
                 response_model=EnhancedQuestionGeneration,
                 model=ALTERNATIVE_LLM_BIG,
                 messages=prompt_messages,
+                timeout=900,
             )
 
     association_id = completion_org.datarobot_moderations["association_id"]
@@ -1531,6 +1535,7 @@ async def get_business_analysis(
                     model=ALTERNATIVE_LLM_BIG,
                     temperature=0.1,
                     messages=messages,
+                    timeout=900,
                 )
         association_id = completion_org.datarobot_moderations["association_id"]
         logger.info(f"Association ID: {association_id}")
@@ -1880,6 +1885,7 @@ async def _generate_database_analysis_code(
                     model=ALTERNATIVE_LLM_BIG,
                     temperature=0.1,
                     messages=messages,
+                    timeout=900,
                 )
             except ValidationError as e:
                 logger.error(f"LLM returned invalid database analysis response: {e}")

--- a/core/src/core/llm_client.py
+++ b/core/src/core/llm_client.py
@@ -30,7 +30,6 @@ from openai import (
     APIError,
     APIStatusError,
     APITimeoutError,
-    AsyncOpenAI,
     AuthenticationError,
     BadRequestError,
     InternalServerError,
@@ -152,15 +151,6 @@ class LLMClientConfig:
                 "LLM_MAX_RETRIES",
                 _DEFAULT_MAX_RETRIES,
             ),
-        )
-
-    @property
-    def should_use_litellm(self) -> bool:
-        """Return whether this config should use the LiteLLM adapter."""
-        return bool(
-            self.use_datarobot_llm_gateway
-            or self.llm_deployment_id
-            or self.default_model
         )
 
     @property
@@ -292,23 +282,6 @@ def _set_llm_span_attributes(
         )
         if response is not None:
             span.set_attribute("gen_ai.output.messages", str(response))
-
-
-class CompletionTokenCompatibilityProxy:
-    """Proxy that normalizes deprecated completion token parameters."""
-
-    def __init__(self, completions: Any):
-        self._completions = completions
-
-    async def create(self, *args: Any, **kwargs: Any) -> Any:
-        return await self._completions.create(
-            *args,
-            **_normalize_completion_token_kwargs(kwargs),
-        )
-
-    def __getattr__(self, name: str) -> Any:
-        """Delegate other attributes to underlying completions object."""
-        return getattr(self._completions, name)
 
 
 class TokenTrackingProxy:
@@ -613,49 +586,19 @@ class AsyncLLMClient:
 
         Args:
             token_tracker: Optional token usage tracker
-            dr_client: Optional DataRobot client (will be initialized if not provided)
-            deployment_base_url: Optional deployment URL (will be initialized if not provided)
+            dr_client: Optional DataRobot client used to fill the LiteLLM API token
+            deployment_base_url: Deprecated compatibility argument; LiteLLM routing
+                uses LLMClientConfig instead.
         """
         self.token_tracker = token_tracker
         self._dr_client = dr_client
-        self._deployment_base_url = deployment_base_url
+        del deployment_base_url
         self._llm_config = llm_config or LLMClientConfig.from_env()
-        self._openai_client: AsyncOpenAI | None = None
         self._instructor_client: instructor.AsyncInstructor | None = None
 
     async def __aenter__(self) -> TokenTrackingProxy:
         """Initialize clients on context entry."""
-        if self._llm_config.should_use_litellm:
-            return self._create_litellm_client()
-
-        # Import here to avoid circular imports
-        from core.api import initialize_deployment
-
-        # Initialize deployment if not provided
-        if self._dr_client is None or self._deployment_base_url is None:
-            dr_client, deployment_base_url = initialize_deployment()
-            self._dr_client = dr_client
-            self._deployment_base_url = deployment_base_url
-
-        # Create OpenAI client
-        self._openai_client = AsyncOpenAI(
-            api_key=self._dr_client.token,
-            base_url=self._deployment_base_url,
-            timeout=self._llm_config.timeout,
-            max_retries=2,
-        )
-        setattr(
-            self._openai_client.chat,
-            "completions",
-            CompletionTokenCompatibilityProxy(self._openai_client.chat.completions),
-        )
-
-        # Create instructor client
-        self._instructor_client = instructor.from_openai(
-            self._openai_client, mode=instructor.Mode.MD_JSON
-        )
-        # Return proxy that tracks tokens
-        return TokenTrackingProxy(self._instructor_client, self.token_tracker)
+        return self._create_litellm_client()
 
     def _create_litellm_client(self) -> TokenTrackingProxy:
         if litellm is None:
@@ -684,5 +627,4 @@ class AsyncLLMClient:
         exc_tb: TracebackType | None,
     ) -> None:
         """Clean up clients on context exit."""
-        if self._openai_client:
-            await self._openai_client.close()
+        return None

--- a/core/src/core/llm_client.py
+++ b/core/src/core/llm_client.py
@@ -39,6 +39,7 @@ from openai import (
 )
 from opentelemetry import trace
 
+from core.config import Config
 from core.constants import get_llm_model
 
 try:
@@ -54,7 +55,7 @@ _MODEL_ALIASES_FOR_CONFIG_DEFAULT = {
     "unknown",
     "",
 }
-_DEFAULT_REQUEST_TIMEOUT_SECONDS = 180.0
+_DEFAULT_REQUEST_TIMEOUT_SECONDS = 900.0
 _DEFAULT_MAX_RETRIES = 2
 _CAPTURE_CONTENT_ENV = "LLM_CAPTURE_CONTENT"
 
@@ -117,19 +118,30 @@ class LLMClientConfig:
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> "LLMClientConfig":
-        """Create config from environment variables only."""
+        """Create config from environment variables and upstream Config defaults."""
         env = os.environ if env is None else env
+        try:
+            config = Config()
+        except Exception:
+            config = None
+
         return cls(
-            default_model=env.get("LLM_DEFAULT_MODEL") or None,
+            default_model=env.get("LLM_DEFAULT_MODEL")
+            or getattr(config, "llm_default_model", None),
             use_datarobot_llm_gateway=_env_bool(
                 env,
                 "USE_DATAROBOT_LLM_GATEWAY",
+                bool(getattr(config, "use_datarobot_llm_gateway", False)),
             ),
             llm_deployment_id=(
-                env.get("LLM_DEPLOYMENT_ID") or env.get("TEXTGEN_DEPLOYMENT_ID")
+                env.get("LLM_DEPLOYMENT_ID")
+                or env.get("TEXTGEN_DEPLOYMENT_ID")
+                or getattr(config, "llm_deployment_id", None)
             ),
-            datarobot_endpoint=env.get("DATAROBOT_ENDPOINT") or None,
-            datarobot_api_token=env.get("DATAROBOT_API_TOKEN") or None,
+            datarobot_endpoint=env.get("DATAROBOT_ENDPOINT")
+            or getattr(config, "datarobot_endpoint", None),
+            datarobot_api_token=env.get("DATAROBOT_API_TOKEN")
+            or getattr(config, "datarobot_api_token", None),
             timeout=_env_float(
                 env,
                 "LLM_REQUEST_TIMEOUT_SECONDS",
@@ -191,6 +203,28 @@ def _normalize_completion_token_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]
     if max_tokens is not None and "max_completion_tokens" not in normalized_kwargs:
         normalized_kwargs["max_completion_tokens"] = max_tokens
     return normalized_kwargs
+
+
+def _create_litellm_instructor() -> instructor.AsyncInstructor:
+    litellm_instructor = instructor.from_litellm(
+        litellm.acompletion,
+        mode=instructor.Mode.MD_JSON,
+    )
+    if isinstance(litellm_instructor, instructor.AsyncInstructor):
+        return litellm_instructor
+
+    # instructor 1.3.4 checks inspect.isawaitable() in from_litellm(), which
+    # misclassifies coroutine functions such as litellm.acompletion as sync.
+    # Prefer upstream from_litellm(), then keep the async fallback required for
+    # create_with_completion.
+    return instructor.AsyncInstructor(
+        client=None,
+        create=instructor.patch(
+            create=litellm.acompletion,
+            mode=instructor.Mode.MD_JSON,
+        ),
+        mode=instructor.Mode.MD_JSON,
+    )
 
 
 def _usage_value(response: Any, *names: str) -> int | None:
@@ -453,7 +487,7 @@ class CompletionsProxy:
 
             # Track tokens if tracker is available
             if self._tracker:
-                self._tracker.track_call(messages, result, model)
+                self._tracker.track_call(messages, org, model)
 
             log.debug(f"LLM API call completed successfully - model: {model}")
             return result, org
@@ -607,7 +641,7 @@ class AsyncLLMClient:
         self._openai_client = AsyncOpenAI(
             api_key=self._dr_client.token,
             base_url=self._deployment_base_url,
-            timeout=180,
+            timeout=self._llm_config.timeout,
             max_retries=2,
         )
         setattr(
@@ -635,18 +669,7 @@ class AsyncLLMClient:
             if dr_token:
                 llm_config = replace(llm_config, datarobot_api_token=dr_token)
 
-        # instructor 1.3.4 checks inspect.isawaitable() in from_litellm(), which
-        # misclassifies coroutine functions such as litellm.acompletion as sync.
-        # Build the AsyncInstructor explicitly so create_with_completion awaits
-        # the LiteLLM coroutine before reading _raw_response.
-        self._instructor_client = instructor.AsyncInstructor(
-            client=None,
-            create=instructor.patch(
-                create=litellm.acompletion,
-                mode=instructor.Mode.MD_JSON,
-            ),
-            mode=instructor.Mode.MD_JSON,
-        )
+        self._instructor_client = _create_litellm_instructor()
         return TokenTrackingProxy(
             self._instructor_client,
             self.token_tracker,

--- a/customize_docs/llm_wrapper_upstream_alignment_20260629.md
+++ b/customize_docs/llm_wrapper_upstream_alignment_20260629.md
@@ -12,6 +12,7 @@
   - DataRobot endpoint / token / deployment id も Config 由来の値を利用する。
 - LiteLLM adapter は `instructor.from_litellm()` を優先する。
   - 現在の instructor は coroutine function を sync と誤判定する場合があるため、`AsyncInstructor` fallback は維持する。
+- `AsyncLLMClient` の OpenAI fallback 経路を削除し、upstream と同じく LiteLLM 経路に一本化した。
 - `create_with_completion` の token tracking は、Pydantic response ではなく raw completion を使うようにした。
 
 ## Tests
@@ -19,6 +20,7 @@
 - `app_backend/tests/test_llm_client.py`
   - `create_with_completion` が raw completion を token tracking に渡すこと。
   - Config 既定値から `custom-model` / timeout 900 が解決されること。
+  - 空の `LLMClientConfig()` でも OpenAI fallback に落ちず LiteLLM を使うこと。
   - LiteLLM 経路で `from_litellm()` を優先し、必要時のみ async fallback すること。
 - `app_backend/tests/test_llm_upstream_alignment.py`
   - `core/src/core/api.py` の `create_with_completion` 呼び出しが `timeout=900` を明示していること。

--- a/customize_docs/llm_wrapper_upstream_alignment_20260629.md
+++ b/customize_docs/llm_wrapper_upstream_alignment_20260629.md
@@ -1,0 +1,29 @@
+# LLM Wrapper Upstream Alignment
+
+## Scope
+
+2026-06-29 に、association_id 取得のための `create_with_completion` は維持したまま、LLM 呼び出し条件を upstream に寄せた。
+
+## Changes
+
+- `core/src/core/api.py` の `create_with_completion` 呼び出しに `timeout=900` を明示した。
+- `LLMClientConfig.from_env()` が `core.config.Config` の既定値を fallback として使うようにした。
+  - `LLM_DEFAULT_MODEL` が未指定でも upstream と同じ `custom-model` を使う。
+  - DataRobot endpoint / token / deployment id も Config 由来の値を利用する。
+- LiteLLM adapter は `instructor.from_litellm()` を優先する。
+  - 現在の instructor は coroutine function を sync と誤判定する場合があるため、`AsyncInstructor` fallback は維持する。
+- `create_with_completion` の token tracking は、Pydantic response ではなく raw completion を使うようにした。
+
+## Tests
+
+- `app_backend/tests/test_llm_client.py`
+  - `create_with_completion` が raw completion を token tracking に渡すこと。
+  - Config 既定値から `custom-model` / timeout 900 が解決されること。
+  - LiteLLM 経路で `from_litellm()` を優先し、必要時のみ async fallback すること。
+- `app_backend/tests/test_llm_upstream_alignment.py`
+  - `core/src/core/api.py` の `create_with_completion` 呼び出しが `timeout=900` を明示していること。
+
+## Notes
+
+- association_id 取得のため、`create_with_completion` 自体は残す。
+- JSON EOF の直接対策ではなく、upstream と異なる LLM wrapper 条件を減らすための PR。


### PR DESCRIPTION
## Scope
- Keep `create_with_completion` so raw completions remain available for DataRobot `association_id`.
- Align LLM wrapper behavior with upstream for timeout/config/LiteLLM adapter handling.
- Remove the OpenAI fallback path so `AsyncLLMClient` always routes through LiteLLM, matching upstream.
- Fix token tracking for `create_with_completion` to use the raw completion response.

## Root Cause
The fork kept association_id support via `create_with_completion`, but surrounding wrapper behavior drifted from upstream: calls omitted upstream `timeout=900`, `LLMClientConfig` ignored `Config` defaults, the client still retained an OpenAI fallback path, and token tracking observed the structured Pydantic result instead of the raw completion.

## Changes
- Add `timeout=900` to core API `create_with_completion` calls that correspond to upstream LLM calls.
- Make `LLMClientConfig.from_env()` fall back to `core.config.Config` defaults, including `custom-model`.
- Use LiteLLM for all `AsyncLLMClient` paths; remove `AsyncOpenAI` fallback and its compatibility proxy.
- Prefer `instructor.from_litellm()` while retaining the async fallback needed when Instructor misclassifies `litellm.acompletion`.
- Track raw completions for `create_with_completion`.
- Add focused tests and a customize doc.

## Testing
- `uv run pytest app_backend/tests/test_llm_client.py app_backend/tests/test_llm_upstream_alignment.py app_backend/tests/test_api_validation_errors_v0424_compat.py -q`
- `uv run ruff check core/src/core/llm_client.py core/src/core/api.py app_backend/tests/test_llm_client.py app_backend/tests/test_llm_upstream_alignment.py`
- `uv run ruff format --check core/src/core/llm_client.py core/src/core/api.py app_backend/tests/test_llm_client.py app_backend/tests/test_llm_upstream_alignment.py`

## Notes
This PR does not remove `create_with_completion` and does not change the JSON EOF retry strategy directly. It reduces upstream drift around the LLM call path first.