### PR TITLE
[codex] Restore submit actuals telemetry

### DIFF
--- a/app_backend/tests/test_api_analysis_execution_v0424_compat.py
+++ b/app_backend/tests/test_api_analysis_execution_v0424_compat.py
@@ -11,6 +11,7 @@ from datarobot_genai.core.utils.token_tracking import (
     TiktokenCountingStrategy,
     TokenUsageTracker,
 )
+from starlette.requests import Request
 
 os.environ.setdefault("DATAROBOT_API_TOKEN", "test-token")
 os.environ.setdefault("DATAROBOT_ENDPOINT", "https://example.com")
@@ -85,6 +86,62 @@ def _analysis_context(analyst_db: Any) -> api.RunCompleteAnalysisRequestContext:
         in_progress=True,
     )
     return context
+
+
+def test_chat_router_task_passes_telemetry_json_to_run_complete_analysis(
+    monkeypatch,
+) -> None:
+    asyncio.run(_assert_chat_router_task_passes_telemetry_json(monkeypatch))
+
+
+async def _assert_chat_router_task_passes_telemetry_json(monkeypatch) -> None:
+    from core.routers import chats
+
+    captured_kwargs: dict[str, Any] = {}
+
+    class FakeAnalystDB:
+        user_id = "user-1"
+
+        async def list_analyst_dataset_metadata(
+            self, data_source: InternalDataSourceType
+        ) -> list[DatasetMetadata]:
+            assert data_source in {
+                InternalDataSourceType.REGISTRY,
+                InternalDataSourceType.FILE,
+            }
+            return [_dataset_metadata("sales")]
+
+    async def fake_run_complete_analysis(**kwargs: Any):
+        captured_kwargs.update(kwargs)
+        if False:
+            yield None
+
+    monkeypatch.setattr(chats, "run_complete_analysis", fake_run_complete_analysis)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v1/chats/chat-1/messages",
+            "headers": [(b"x-user-email", b"analyst@example.com")],
+        }
+    )
+
+    await chats.run_complete_analysis_task(
+        chat_request=ChatRequest(messages=[{"role": "user", "content": "sum amount"}]),
+        data_source=InternalDataSourceType.FILE.value,
+        analyst_db=FakeAnalystDB(),  # type: ignore[arg-type]
+        chat_id="chat-1",
+        message_id="message-1",
+        enable_chart_generation=True,
+        enable_business_insights=False,
+        request=request,
+    )
+
+    assert captured_kwargs["telemetry_json"] == {
+        "user_email": "analyst@example.com",
+        "user_msg": "sum amount",
+    }
 
 
 def test_stage_message_update_persists_ordered_message_snapshots() -> None:

--- a/core/src/core/routers/chats.py
+++ b/core/src/core/routers/chats.py
@@ -106,6 +106,12 @@ async def run_complete_analysis_task(
     else:
         dataset_metadata = await analyst_db.list_analyst_dataset_metadata(source)
 
+    user_email = request.headers.get("x-user-email")
+    logger.info(f"Sending request on behalf of {user_email}")
+    telemetry_json = {
+        "user_email": user_email,
+        "user_msg": chat_request.messages[-1]["content"],
+    }
     run_analysis_iterator = run_complete_analysis(
         chat_request=chat_request,
         data_source=source,
@@ -115,6 +121,7 @@ async def run_complete_analysis_task(
         message_id=message_id,
         enable_chart_generation=enable_chart_generation,
         enable_business_insights=enable_business_insights,
+        telemetry_json=telemetry_json,
         request=request,
     )
 

--- a/customize_docs/submit_actuals_telemetry_restore_20260629.md
+++ b/customize_docs/submit_actuals_telemetry_restore_20260629.md
@@ -1,0 +1,24 @@
+# Submit Actuals Telemetry Restore
+
+## 背景
+
+2026-06-22 の router split 後、チャット実行経路の
+`core.routers.chats.run_complete_analysis_task()` から
+`core.api.run_complete_analysis()` へ `telemetry_json` が渡されなくなっていた。
+
+`run_complete_analysis()` 配下の LLM 呼び出しは `telemetry_json is not None` の場合だけ
+`async_submit_actuals_to_datarobot()` を起動するため、通常チャット経路では actuals submit
+まで到達していなかった。
+
+## 変更内容
+
+- 旧 `rest_api.py` と同様に、チャット request の `x-user-email` と最後のユーザーメッセージを
+  `telemetry_json` として復元した。
+- `run_complete_analysis()` 呼び出しに `telemetry_json=telemetry_json` を渡すようにした。
+- 回帰テストとして、router task が `telemetry_json` を `run_complete_analysis()` に渡すことを固定した。
+
+## テスト方針
+
+- RED: `run_complete_analysis_task()` が `telemetry_json` を渡さない現状で失敗することを確認。
+- GREEN: `telemetry_json` 復元後に同テストが通ることを確認。
+- 既存回帰: `run_complete_analysis()` 内部の telemetry propagation と router split の既存テストを実行する。


### PR DESCRIPTION
## Summary

- Restore chat telemetry payload creation in the split chat router.
- Pass `telemetry_json` into `run_complete_analysis()` so submit actuals can run again from the normal chat flow.
- Add a regression test that fixes the router task contract and document the investigation under `customize_docs/`.

## Root Cause

The 2026-06-22 router split moved chat handling from the monolithic `rest_api.py` into `core.routers.chats`, but the old `telemetry_json` construction and `telemetry_json=telemetry_json` argument were not carried over. As a result, `run_complete_analysis()` still ran, but downstream actuals submission was skipped because telemetry was `None`.

## Validation

- `uv run pytest app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_v1151_fastapi_app_factory.py -q`
- `uv run ruff check core/src/core/routers/chats.py app_backend/tests/test_api_analysis_execution_v0424_compat.py`
