### PR TITLE
[codex] Use prediction association id for actuals

### DIFF
--- a/app_backend/tests/test_api_analysis_execution_v0424_compat.py
+++ b/app_backend/tests/test_api_analysis_execution_v0424_compat.py
@@ -3,6 +3,7 @@ import asyncio
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pandas as pd
@@ -86,6 +87,25 @@ def _analysis_context(analyst_db: Any) -> api.RunCompleteAnalysisRequestContext:
         in_progress=True,
     )
     return context
+
+
+def test_datarobot_association_id_prefers_prediction_association_id() -> None:
+    completion_response = SimpleNamespace(
+        datarobot_association_id="prediction-association-id",
+        datarobot_moderations={"association_id": "moderation-association-id"},
+    )
+
+    assert (
+        api._get_datarobot_association_id(completion_response)
+        == "prediction-association-id"
+    )
+
+
+def test_datarobot_association_id_requires_prediction_association_id() -> None:
+    completion_response = SimpleNamespace(datarobot_moderations={"association_id": "x"})
+
+    with pytest.raises(ValueError, match="datarobot_association_id"):
+        api._get_datarobot_association_id(completion_response)
 
 
 def test_chat_router_task_passes_telemetry_json_to_run_complete_analysis(

--- a/core/src/core/api.py
+++ b/core/src/core/api.py
@@ -161,6 +161,15 @@ def log_memory() -> None:
     logger.info(f"Memory usage: {memory:.2f} MB")
 
 
+def _get_datarobot_association_id(completion_response: Any) -> str:
+    association_id = getattr(completion_response, "datarobot_association_id", None)
+    if association_id is None and isinstance(completion_response, dict):
+        association_id = completion_response.get("datarobot_association_id")
+    if not association_id:
+        raise ValueError("DataRobot response did not include datarobot_association_id.")
+    return str(association_id)
+
+
 @functools.cache
 def initialize_deployment() -> tuple[RESTClientObject, str]:
     """Initialize either LLM Gateway or DataRobot-hosted LLM deployment based on environment settings and credential priority."""
@@ -648,7 +657,7 @@ async def _get_dictionary_batch(
 
         # Convert to dictionary format
         descriptions = completion.to_dict()
-        association_id = completion_org.datarobot_moderations["association_id"]
+        association_id = _get_datarobot_association_id(completion_org)
         logger.info(f"Association ID: {association_id}")
 
         if telemetry_send is not None:
@@ -1006,7 +1015,7 @@ async def _generate_run_charts_python_code(
                 messages=messages,
                 timeout=900,
             )
-    association_id = response_org.datarobot_moderations["association_id"]
+    association_id = _get_datarobot_association_id(response_org)
     logger.info(f"Association ID: {association_id}")
     if telemetry_send is not None:
         # add query type to telemetry
@@ -1171,7 +1180,7 @@ async def _generate_run_analysis_python_code(
                 max_retries=10,
                 timeout=900,
             )
-    association_id = completion_org.datarobot_moderations["association_id"]
+    association_id = _get_datarobot_association_id(completion_org)
     logger.info(f"Association ID: {association_id}")
 
     if telemetry_send is not None:
@@ -1353,7 +1362,7 @@ async def rephrase_message(
                 timeout=900,
             )
 
-    association_id = completion_org.datarobot_moderations["association_id"]
+    association_id = _get_datarobot_association_id(completion_org)
     logger.info(f"Association ID: {association_id}")
 
     if telemetry_send is not None:
@@ -1537,7 +1546,7 @@ async def get_business_analysis(
                     messages=messages,
                     timeout=900,
                 )
-        association_id = completion_org.datarobot_moderations["association_id"]
+        association_id = _get_datarobot_association_id(completion_org)
         logger.info(f"Association ID: {association_id}")
 
         if telemetry_send is not None:
@@ -1894,7 +1903,7 @@ async def _generate_database_analysis_code(
                     "This could be due to data quality issues, complex dataset structure, or the question being too complex. "
                     "Try simplifying your question or checking your data."
                 ) from e
-    association_id = completion_org.datarobot_moderations["association_id"]
+    association_id = _get_datarobot_association_id(completion_org)
     logger.info(f"Association ID: {association_id}")
 
     if telemetry_send is not None:

--- a/customize_docs/submit_actuals_telemetry_restore_20260629.md
+++ b/customize_docs/submit_actuals_telemetry_restore_20260629.md
@@ -16,9 +16,31 @@
   `telemetry_json` として復元した。
 - `run_complete_analysis()` 呼び出しに `telemetry_json=telemetry_json` を渡すようにした。
 - 回帰テストとして、router task が `telemetry_json` を `run_complete_analysis()` に渡すことを固定した。
+- actuals submit の association ID は、LLM Gateway レスポンス直下の
+  `datarobot_association_id` を使うようにした。`datarobot_moderations.association_id` は
+  moderation 用の ID で、prediction export の `association_id` とは一致しないため使用しない。
+- `datarobot_association_id` が取得できない場合は、別IDへフォールバックせずにエラーにする。
+
+## 実APIでの整合性確認
+
+対象デプロイ: `6a4230d722173b17e5a9b960`
+
+2026-06-29 に実際の chat completions API と prediction data export を突き合わせた。
+
+- probe: `codex_assoc_probe_20260629T113247Z`
+- chat response の `datarobot_association_id`: `112498d1-dede-493f-b70c-5482d101a1a8`
+- chat response の `datarobot_moderations.association_id`: `c42fafa6-7edb-4387-8ba6-d9b7a0de3b31`
+- export dataset: `6a42588466aaee5f1729ed60`
+- export version: `6a42588466aaee5f1729ed61`
+
+prediction export CSV では、`datarobot_association_id` と同じ
+`112498d1-dede-493f-b70c-5482d101a1a8` の行が 1 件存在し、同じ行に actual_value が付いた。
+一方で `datarobot_moderations.association_id` の行は 0 件だった。
 
 ## テスト方針
 
 - RED: `run_complete_analysis_task()` が `telemetry_json` を渡さない現状で失敗することを確認。
 - GREEN: `telemetry_json` 復元後に同テストが通ることを確認。
 - 既存回帰: `run_complete_analysis()` 内部の telemetry propagation と router split の既存テストを実行する。
+- association ID: `datarobot_association_id` を使い、`datarobot_moderations.association_id` に
+  フォールバックしないことを単体テストで固定する。


### PR DESCRIPTION
## Summary

- Use the chat completions response top-level `datarobot_association_id` for submit actuals.
- Do not fall back to `datarobot_moderations.association_id`; that ID does not appear in prediction export rows.
- Add regression tests for association ID selection and document the live DataRobot verification.

## Root Cause

The current code used `datarobot_moderations["association_id"]` as the association ID for actuals. The DataRobot actuals endpoint can return `202` for that POST, but the ID is not the prediction row association ID, so the actual does not attach to prediction history.

## Live Verification

Deployment: `6a4230d722173b17e5a9b960`

- probe: `codex_assoc_probe_20260629T113247Z`
- top-level `datarobot_association_id`: `112498d1-dede-493f-b70c-5482d101a1a8`
- `datarobot_moderations.association_id`: `c42fafa6-7edb-4387-8ba6-d9b7a0de3b31`
- prediction export dataset/version: `6a42588466aaee5f1729ed60` / `6a42588466aaee5f1729ed61`
- export row count for top-level ID: 1, with the posted `actual_value` attached
- export row count for moderation ID: 0

## Validation

- `uv run pytest app_backend/tests/test_api_analysis_execution_v0424_compat.py app_backend/tests/test_v1151_fastapi_app_factory.py -q`
- `uv run ruff check core/src/core/api.py core/src/core/routers/chats.py app_backend/tests/test_api_analysis_execution_v0424_compat.py`
