### PR TITLE
[codex] Fix report persistence and sidebar entrypoint

### DIFF
--- a/app_backend/tests/test_report_storage.py
+++ b/app_backend/tests/test_report_storage.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from core.customize.domain.report.domain import (
+    QuestionStatus,
+    Report,
+    ReportQuestion,
+    ReportStatus,
+)
+from core.customize.infrastructure.storage.report_storage import ReportStorage
+
+
+class FakePersistentStorage:
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+        self.deleted_files: list[str] = []
+
+    async def fetch_from_storage(self, file_name: str, local_path: str) -> None:
+        if file_name not in self.files:
+            return
+        Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(local_path).write_bytes(self.files[file_name])
+
+    async def save_to_storage(self, file_name: str, local_path: str) -> None:
+        await asyncio.sleep(0)
+        self.files[file_name] = Path(local_path).read_bytes()
+
+    async def delete_file(self, file_name: str) -> None:
+        self.deleted_files.append(file_name)
+        self.files.pop(file_name, None)
+
+
+def _new_report_storage(
+    *,
+    tmp_path: Path,
+    user_id: str,
+    fake_storage: FakePersistentStorage,
+    run_name: str,
+) -> ReportStorage:
+    storage = ReportStorage(user_id)
+    storage._storage = fake_storage
+    storage._base_dir = tmp_path / run_name
+    storage._base_dir.mkdir(parents=True, exist_ok=True)
+    return storage
+
+
+def _report(*, report_id: str, user_id: str) -> Report:
+    return Report(
+        report_id=report_id,
+        title="Sales report",
+        theme="売上要因を分析したい",
+        user_id=user_id,
+        status=ReportStatus.COMPLETED,
+        questions=[
+            ReportQuestion(
+                question_id="question-1",
+                original_direction="売上の前年差を知りたい",
+                refined_question="売上の前年差を店舗別に集計して",
+                status=QuestionStatus.COMPLETED,
+            )
+        ],
+    )
+
+
+async def _assert_save_persists_report_and_index_before_return(
+    tmp_path: Path,
+) -> None:
+    user_id = "user-1"
+    fake_storage = FakePersistentStorage()
+    storage = _new_report_storage(
+        tmp_path=tmp_path,
+        user_id=user_id,
+        fake_storage=fake_storage,
+        run_name="run-1",
+    )
+    report = _report(report_id="report-1", user_id=user_id)
+
+    await storage.save(report)
+
+    assert "report_metadata_report-1.json" in fake_storage.files
+    assert "report_index_user-1" in fake_storage.files
+    assert json.loads(fake_storage.files["report_index_user-1"]) == {
+        "report_ids": ["report-1"]
+    }
+
+
+def test_save_persists_report_and_index_before_return(tmp_path: Path) -> None:
+    asyncio.run(_assert_save_persists_report_and_index_before_return(tmp_path))
+
+
+async def _assert_list_by_user_recovers_reports_after_new_run(
+    tmp_path: Path,
+) -> None:
+    user_id = "user-1"
+    fake_storage = FakePersistentStorage()
+    first_run_storage = _new_report_storage(
+        tmp_path=tmp_path,
+        user_id=user_id,
+        fake_storage=fake_storage,
+        run_name="run-1",
+    )
+
+    await first_run_storage.save(_report(report_id="report-1", user_id=user_id))
+
+    second_run_storage = _new_report_storage(
+        tmp_path=tmp_path,
+        user_id=user_id,
+        fake_storage=fake_storage,
+        run_name="run-2",
+    )
+
+    reports = await second_run_storage.list_by_user(user_id)
+
+    assert [report.report_id for report in reports] == ["report-1"]
+
+
+def test_list_by_user_recovers_reports_from_storage_after_new_run(
+    tmp_path: Path,
+) -> None:
+    asyncio.run(_assert_list_by_user_recovers_reports_after_new_run(tmp_path))

--- a/core/src/core/customize/infrastructure/storage/report_storage.py
+++ b/core/src/core/customize/infrastructure/storage/report_storage.py
@@ -10,7 +10,6 @@ import asyncio
 import json
 import os
 import shutil
-import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -82,14 +81,12 @@ class ReportStorage(IReportRepository):
             # 1) まずローカルを原子的に更新（ローカルを常に正とする）
             atomic_write_json(str(local_path), report.to_dict())
 
-            # 2) リモート保存は非同期でスケジュール（読み込みの体感速度を優先）
-            asyncio.create_task(
-                self._storage.save_to_storage(
-                    self._metadata_key(report.report_id), str(local_path)
-                )
+            # 2) 新しい run でも復元できるよう、永続化完了まで待つ
+            await self._storage.save_to_storage(
+                self._metadata_key(report.report_id), str(local_path)
             )
             logger.info(
-                f"Report saved locally and scheduled remote persist: {report.report_id}"
+                f"Report saved locally and persisted remotely: {report.report_id}"
             )
         except Exception as e:
             logger.error(
@@ -183,9 +180,9 @@ class ReportStorage(IReportRepository):
         if local_word.exists():
             local_word.unlink(missing_ok=True)
 
-        # 2) リモート削除は非同期でスケジュール
-        asyncio.create_task(self._storage.delete_file(self._metadata_key(report_id)))
-        asyncio.create_task(self._storage.delete_file(self._word_key(report_id)))
+        # 2) リモート削除も完了まで待つ
+        await self._storage.delete_file(self._metadata_key(report_id))
+        await self._storage.delete_file(self._word_key(report_id))
 
         # インデックスを更新
         await self._update_index(report_id, add=False)
@@ -203,11 +200,9 @@ class ReportStorage(IReportRepository):
             )
             word_copy_path = Path(local_path)
 
-        # リモート保存は非同期でスケジュール（ローカル優先）
-        asyncio.create_task(
-            self._storage.save_to_storage(
-                self._word_key(report_id), str(word_copy_path)
-            )
+        # 新しい run でもダウンロードできるよう、永続化完了まで待つ
+        await self._storage.save_to_storage(
+            self._word_key(report_id), str(word_copy_path)
         )
 
         return self._word_key(report_id)
@@ -268,60 +263,35 @@ class ReportStorage(IReportRepository):
         current_ids = await self._get_index()
 
         if add:
-            if report_id in current_ids:
-                return
-
-            # 新しいIDを追加（完全更新ではなく追記）
-            current_ids.append(report_id)
-
-            # 古い内容を保持したまま保存するため、一時ファイルを使って差分保存
-            with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as tmp:
-                tmp_path = tmp.name
-
-            try:
-                atomic_write_json(tmp_path, {"report_ids": current_ids})
-                # リモート保存は非同期でスケジュール
-                asyncio.create_task(
-                    self._storage.save_to_storage(self._index_key(), tmp_path)
-                )
-            finally:
-                if os.path.exists(tmp_path):
-                    os.remove(tmp_path)
-
-            # ローカルキャッシュも更新
-            atomic_write_json(str(self._index_path()), {"report_ids": current_ids})
-
-        else:
             if report_id not in current_ids:
-                return
+                current_ids.append(report_id)
 
-            # IDを削除
-            current_ids.remove(report_id)
-
-            # 空になった場合は「空を永続化しない」ポリシーに従い、
-            # ストレージキーを削除しローカルキャッシュも削除する
-            if not current_ids:
-                try:
-                    # リモート削除は非同期でスケジュール
-                    asyncio.create_task(self._storage.delete_file(self._index_key()))
-                except Exception as e:  # pragma: no cover
-                    logger.warning(
-                        f"Failed to schedule index delete: {type(e).__name__}: {e}"
-                    )
-
-                index_path = self._index_path()
-                try:
-                    if index_path.exists():
-                        index_path.unlink(missing_ok=True)
-                except Exception as e:  # pragma: no cover
-                    logger.warning(
-                        f"Failed to delete local empty index: {type(e).__name__}: {e}"
-                    )
-                return
-
-            # 空でない場合のみ保存（原子的に書き込み→永続化[非同期]）
             index_path = self._index_path()
             atomic_write_json(str(index_path), {"report_ids": current_ids})
-            asyncio.create_task(
-                self._storage.save_to_storage(self._index_key(), str(index_path))
-            )
+            await self._storage.save_to_storage(self._index_key(), str(index_path))
+            return
+
+        if report_id not in current_ids:
+            return
+
+        # IDを削除
+        current_ids.remove(report_id)
+
+        # 空になった場合は「空を永続化しない」ポリシーに従い、
+        # ストレージキーを削除しローカルキャッシュも削除する
+        if not current_ids:
+            await self._storage.delete_file(self._index_key())
+            index_path = self._index_path()
+            try:
+                if index_path.exists():
+                    index_path.unlink(missing_ok=True)
+            except Exception as e:  # pragma: no cover
+                logger.warning(
+                    f"Failed to delete local empty index: {type(e).__name__}: {e}"
+                )
+            return
+
+        # 空でない場合のみ保存（原子的に書き込み→永続化）
+        index_path = self._index_path()
+        atomic_write_json(str(index_path), {"report_ids": current_ids})
+        await self._storage.save_to_storage(self._index_key(), str(index_path))

--- a/customize_docs/new_spec/REPORT_BUILDER.md
+++ b/customize_docs/new_spec/REPORT_BUILDER.md
@@ -1168,6 +1168,17 @@ PR #35 (`dev` -> `main`) をmainへ進めるため、Report Builder取り込み�
 - OpenAI reasoning系モデルでは `max_tokens` ではなく `max_completion_tokens` / Responses APIの `max_output_tokens` を使う必要があるため、`infra/settings_generative.py` の `LLMSettings.max_completion_length` は未指定にした。
 - `app_backend/tests/test_infra_llm_settings.py` を追加し、LLM Blueprint設定で `max_completion_length` を再度固定しないことをASTベースで確認する。importによるDataRobot SDK初期化を避けるため、設定ファイルを直接parseしている。
 
+### デプロイ後のReport永続化修正（2026-06-30）
+
+- 現象: Report Builderは表示されるが、新規作成・実行したreportが新しいrunで一覧に残らない。
+- 原因: `ReportStorage` が metadata / index / Word のPersistentStorage保存を `asyncio.create_task(...)` で投げっぱなしにしていた。特にindex更新では一時ファイルを非同期taskへ渡した直後に削除していたため、`report_index_{user_id}` が永続化されず、次のrunで一覧復元できなかった。
+- 修正: `ReportStorage.save()` / `_update_index()` / `save_word_file()` / `delete()` で、ローカルキャッシュ更新後にPersistentStorageの保存・削除完了を `await` する。
+- 追加テスト:
+  - `app_backend/tests/test_report_storage.py::test_save_persists_report_and_index_before_return`
+    - `save()` が戻った時点で report metadata と index がPersistentStorageへ保存済みであることを確認。
+  - `app_backend/tests/test_report_storage.py::test_list_by_user_recovers_reports_from_storage_after_new_run`
+    - 別run相当の空ローカルキャッシュから、PersistentStorageのindexとmetadataを使って一覧復元できることを確認。
+
 ---
 
 ## 冗長箇所メモ

--- a/customize_docs/new_spec/infrastructure_storage_improvements.md
+++ b/customize_docs/new_spec/infrastructure_storage_improvements.md
@@ -6,6 +6,12 @@
 - 保存の不安定性（非同期文脈・空データの取り扱い・部分失敗）を解消し、`custom_prompts` と同様の整合的なポリシー（空は保存しない、原子的書き込み、明確なロールバック）に揃える。
 
 ## 実装変更の要点（ReportStorage）
+- Report Builderの永続化完了待ち（2026-06-30）
+  - ファイル参照: utils/customize/infrastructure/storage/report_storage.py
+  - 変更: metadata / index / Word の保存と削除で `asyncio.create_task(...)` を使わず、`PersistentStorage` の処理を `await` する。
+  - 理由: デプロイ環境で request / background task の終了後に投げっぱなし task が完了しないと、新しい run でローカルキャッシュが空になった際に report 一覧を復元できない。
+  - 追加修正: index 追加時に一時ファイルを非同期 task に渡して即削除する処理を廃止し、ローカル index ファイルを原子的に書き込んだ後、そのファイルを永続化する。
+
 - インデックス削除時の空永続化禁止
   - ファイル参照: utils/customize/infrastructure/storage/report_storage.py:271
   - 変更: レポート削除でインデックスが空になった場合、`save_to_storage` による空JSONの永続化を行わず、`delete_file(self._index_key())` を呼び出し、ローカルキャッシュも削除。
@@ -64,3 +70,7 @@
 - 非同期文脈での保存
   - 前提: FastAPIエンドポイントから呼び出し。
   - 検証: `save_word_file` / `save` が await で動作し、保存スキップが発生しない。
+
+- 新しい run での一覧復元
+  - 手順: 1つ目の `ReportStorage` インスタンスで `save(report)` を実行後、別のローカルキャッシュディレクトリを使う2つ目の `ReportStorage` で `list_by_user(user_id)` を実行。
+  - 検証: PersistentStorage から `report_index_{user_id}` と metadata を取得し、保存済み report が一覧に戻る。

--- a/customize_docs/new_spec/storage_local_first_spec.md
+++ b/customize_docs/new_spec/storage_local_first_spec.md
@@ -1,23 +1,24 @@
-# ストレージ仕様（ローカル優先・非同期永続化）
+# ストレージ仕様（ローカル優先・同期永続化）
 
 対象: レポート保存のインフラ層 `utils/customize/infrastructure/storage/report_storage.py`
 
 ## 目的
 - 読み込みの体感速度を最大化するため「ローカル優先」を徹底する。
-- ローカルの状態を常に正とし、リモート（永続ストレージ）への保存・削除は非同期に行う。
+- ローカルを原子的に更新したうえで、リモート（永続ストレージ）への保存・削除完了を待つ。
 - ローカルになければストレージから取得してローカルを最新化する。
+- 新しいアプリ run でもレポート一覧を復元できるよう、metadata と index は `save()` 完了時点で永続化済みにする。
 
 ## ポリシー
 - 読み込みはローカル優先（存在しなければ取得→ローカルへ反映）
-- 書き込み・削除はローカルを原子的に更新後に、非同期でリモートへ反映
+- 書き込み・削除はローカルを原子的に更新後に、リモート反映完了まで待つ
 - 空データは永続化しない（インデックスが空ならストレージキーを削除）
-- 失敗はログ記録し、読み込みの可用性を優先（最終的にローカルが正）
+- リモート保存失敗は呼び出し元へ伝播し、成功扱いでデータ欠落しないようにする
 
 ## 実装詳細（関数単位）
 
 - `save(report)` （レポートメタデータの保存）
   - ローカルに原子的に書き込み（JSON）
-  - リモート保存を `asyncio.create_task(...)` で非同期スケジュール
+  - リモート保存完了まで `await` する
   - 行参照: utils/customize/infrastructure/storage/report_storage.py:83, utils/customize/infrastructure/storage/report_storage.py:86
 
 - `get(report_id)` / `_get_once(report_id)` （レポート取得）
@@ -27,12 +28,12 @@
 
 - `delete(report_id)` （削除）
   - まずローカルのメタデータ・Wordを削除
-  - リモート削除を `asyncio.create_task(...)` で非同期スケジュール
+  - リモート削除完了まで `await` する
   - 行参照: utils/customize/infrastructure/storage/report_storage.py:187, utils/customize/infrastructure/storage/report_storage.py:188
 
 - `save_word_file(report_id, local_path)` （Word保存）
   - ローカルにコピー（壊れていれば入力パスを利用）
-  - リモート保存を非同期スケジュール
+  - リモート保存完了まで `await` する
   - 行参照: utils/customize/infrastructure/storage/report_storage.py:204, utils/customize/infrastructure/storage/report_storage.py:207
 
 - `get_word_file(report_id, local_path)` （Word取得）
@@ -45,14 +46,14 @@
   - 行参照: utils/customize/infrastructure/storage/report_storage.py:241, utils/customize/infrastructure/storage/report_storage.py:248
 
 - `_update_index(report_id, add)` （インデックス更新）
-  - 追加時：一時ファイル＋原子的書き込み→非同期でリモート保存→ローカルキャッシュ更新
-  - 削除時：空になれば非同期でストレージキー削除、ローカルファイルも削除
-  - 空でなければ原子的書き込み→非同期でリモート保存
+  - 追加時：ローカル index を原子的に書き込み→リモート保存完了まで `await`
+  - 削除時：空になればストレージキー削除完了まで `await` し、ローカルファイルも削除
+  - 空でなければ原子的書き込み→リモート保存完了まで `await`
   - 行参照: utils/customize/infrastructure/storage/report_storage.py:280, utils/customize/infrastructure/storage/report_storage.py:282, utils/customize/infrastructure/storage/report_storage.py:323
 
 ## 失敗時の挙動
-- リモート保存・削除の失敗はログに記録（非同期タスク内）
-- 読み込みはローカルを優先するため、リモート障害でも影響を最小化
+- リモート保存・削除の失敗は呼び出し元へ伝播する。
+- 読み込みは引き続きローカルを優先するため、同一 run 内の体感速度は維持する。
 - 既知の改善余地：`PersistentStorage.save_to_storage()` の部分失敗ロールバック（次の改修提案に記載）
 
 ## データ配置
@@ -69,5 +70,11 @@
 
 ## 注意点
 - `PersistentStorage` が利用不可（環境変数未設定など）の場合、`NullPersistentStorage` にフォールバックし、ローカルのみで動作
-- 高負荷時の非同期タスクの競合に注意（同じ `report_id` の同時保存は避ける）
+- 同じ `report_id` の同時保存は避ける。
 
+## 2026-06-30 修正メモ
+
+- 旧実装では `asyncio.create_task(...)` で metadata / index / Word 保存を投げっぱなしにしていた。
+- 特に index 更新では、一時ファイルを非同期 task に渡した直後に削除していたため、PersistentStorage へ `report_index_{user_id}` が保存されないことがあった。
+- 新しい run ではローカルキャッシュが空のため、index が永続化されていないと metadata が残っていても一覧に出ない。
+- `ReportStorage.save()` / `_update_index()` / `save_word_file()` / `delete()` は、永続化または削除が完了するまで `await` する。

--- a/customize_docs/test_taskfile_deployment_dx.py
+++ b/customize_docs/test_taskfile_deployment_dx.py
@@ -75,7 +75,7 @@ def test_cli_base_uses_runtime_database_connection_selection() -> None:
     assert {
         option.get("value", option["name"])
         for option in env_entries["DATABASE_CONNECTION_TYPE"]["options"]
-    } == {"no_database", "snowflake", "bigquery", "sap"}
+    } == {"no_database", "snowflake", "bigquery", "sap", "datarobot_jdbc"}
     assert "enable_snowflake" not in key_entries
     assert "enable_bigquery" not in key_entries
     assert "enable_sap_datasphere" not in key_entries


### PR DESCRIPTION
## Summary
- persist report metadata, index, Word files, and deletes before ReportStorage returns
- remove the async temp-file index save path that could drop report_index between app runs
- add regression tests for save durability and list recovery from a fresh local cache
- move Report Builder into the sidebar flow as Datasets -> Chats -> Reports
- replace the icon-only report entry with a + New Report button that opens /reports?new=1
- add Japanese translation for New Report and document the storage/sidebar behavior

## Root cause
ReportStorage scheduled PersistentStorage writes with asyncio.create_task and returned before those writes completed. The report index path was worse: it scheduled a write from a temporary file and deleted that file immediately, so report_index_{user_id} could fail to persist. A new deployed run starts with an empty local cache, so list_by_user could not discover saved reports even if report metadata had been uploaded.

The sidebar also treated Reports differently from Datasets and Chats: it had a constrained report section and an icon-only action, which made the Report Builder entry hard to discover.

## Validation
- uv run ruff check core/src/core/customize/infrastructure/storage/report_storage.py app_backend/tests/test_report_storage.py customize_docs/test_taskfile_deployment_dx.py
- uv run pytest app_backend/tests/test_report_storage.py app_backend/tests/test_llm_timeout.py customize_docs/test_word_generation_llm.py
- uv run pytest app_backend/tests
- uv run pytest customize_docs
- npm run test -- tests/components/Sidebar.test.tsx
- npm exec eslint -- src/components/Sidebar.tsx src/pages/Reports.tsx tests/components/Sidebar.test.tsx
- npm exec tsc -- -b tsconfig.app.json
- npm run test
- npm run lint

## Notes
- npm run build reached Vite bundling and failed in this local checkout because Rollup could not resolve unenv/node/process from node_modules/.pnpm/react@19.2.7/node_modules/react/jsx-runtime.js. TypeScript, lint, and tests passed.

## Rollout
Deploying this makes report create/execute wait for durable metadata/index writes. If PersistentStorage is unavailable, the existing NullPersistentStorage fallback still preserves local-only behavior for non-deployed/local contexts.