### PR TITLE
[codex] Improve report builder sidebar entrypoint

### DIFF
--- a/app_frontend/src/components/Sidebar.tsx
+++ b/app_frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { FileText, Loader2, Settings } from "lucide-react";
+import { Loader2, Plus, Settings } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useFetchAllChats, getChatsMenu } from "@/api/chat-messages";
@@ -124,22 +124,29 @@ const ReportList = () => {
 
   const reportMenuOptions: SidebarMenuOptionType[] =
     data?.reports?.map((report) => ({
+      key: report.report_id,
       id: report.report_id,
       name: report.title,
     })) || [];
 
   return (
-    <div className="relative flex max-h-[200px] flex-none flex-col">
+    <div className="relative flex h-full flex-1 flex-col">
       <div className="flex items-center justify-between pb-3 pl-2">
         <div>
           <p className="mn-label-large">{t("Reports")}</p>
         </div>
         <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => navigate(ROUTES.REPORTS)}
+          className="mr-2"
+          variant="secondary"
+          onClick={() =>
+            navigate({
+              pathname: ROUTES.REPORTS,
+              search: "?new=1",
+            })
+          }
         >
-          <FileText />
+          <Plus />
+          {t("New Report")}
         </Button>
       </div>
       <div className="flex-1 overflow-y-auto">
@@ -195,15 +202,10 @@ export const Sidebar = () => {
             )}
           </p>
         </SidebarHeader>
-        <SidebarContent className="max-h-[300px] flex-none">
-          <Separator className="my-6" />
-          <SidebarGroup className="h-full">
-            <DatasetList highlight={highlightDatasets} />
-          </SidebarGroup>
-        </SidebarContent>
-        <Separator className="my-6" />
         <SidebarContent>
           <SidebarGroup className="h-full">
+            <DatasetList highlight={highlightDatasets} />
+            <Separator className="my-6" />
             <ChatList highlight={highlightChats} />
             {showReportBuilder && (
               <>

--- a/app_frontend/src/i18n/locales/ja.json
+++ b/app_frontend/src/i18n/locales/ja.json
@@ -103,6 +103,7 @@
   "Remote Registry": "リモートレジストリ",
   "Local Registry / File": "ローカルレジストリ/ファイル",
   "New chat": "新しいチャット",
+  "New Report": "新しいレポート",
   "Create new chat": "新しいチャットを作成",
   "Creating a new chat does not affect any of your existing questions.": "新しいチャットを作成しても、既存の質問には影響しません。",
   "Chat name": "チャット名",

--- a/app_frontend/src/pages/Reports.tsx
+++ b/app_frontend/src/pages/Reports.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useState, useCallback, useEffect, useRef } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { isAxiosError } from "axios";
 import { useTranslation } from "@/i18n";
 import {
@@ -807,7 +807,14 @@ export const Reports = () => {
   const { reportId } = useParams();
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [showCreateForm, setShowCreateForm] = useState(
+    () => searchParams.get("new") === "1",
+  );
+
+  useEffect(() => {
+    setShowCreateForm(searchParams.get("new") === "1");
+  }, [searchParams]);
 
   const handleReportCreated = (newReportId: string) => {
     setShowCreateForm(false);
@@ -831,7 +838,12 @@ export const Reports = () => {
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold">{t("Report Builder")}</h1>
           {!showCreateForm && (
-            <Button onClick={() => setShowCreateForm(true)}>
+            <Button
+              onClick={() => {
+                setShowCreateForm(true);
+                setSearchParams({ new: "1" });
+              }}
+            >
               <Plus className="mr-2 size-4" />
               {t("New Report")}
             </Button>
@@ -841,7 +853,13 @@ export const Reports = () => {
         {showCreateForm && (
           <>
             <CreateReportForm onSuccess={handleReportCreated} />
-            <Button variant="ghost" onClick={() => setShowCreateForm(false)}>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setShowCreateForm(false);
+                setSearchParams({});
+              }}
+            >
               {t("Cancel")}
             </Button>
             <Separator />

--- a/app_frontend/tests/components/Sidebar.test.tsx
+++ b/app_frontend/tests/components/Sidebar.test.tsx
@@ -78,9 +78,12 @@ describe("Sidebar Report Builder feature flag", () => {
     renderWithProviders(<Sidebar />);
 
     expect(screen.queryByText("Reports")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "New Report" }),
+    ).not.toBeInTheDocument();
   });
 
-  test("shows Report Builder navigation when the flag is enabled", () => {
+  test("shows Report Builder after chats when the flag is enabled", () => {
     mockUseFetchFeatureFlags.mockReturnValue({
       data: { ...featureFlags, reportBuilderEnabled: true },
     } as any);
@@ -88,5 +91,13 @@ describe("Sidebar Report Builder feature flag", () => {
     renderWithProviders(<Sidebar />);
 
     expect(screen.getByText("Reports")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "New Report" }),
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getAllByText(/Datasets|Chats|Reports/)
+        .map((node) => node.textContent),
+    ).toEqual(["Datasets", "Chats", "Reports"]);
   });
 });

--- a/customize_docs/new_spec/REPORT_BUILDER.md
+++ b/customize_docs/new_spec/REPORT_BUILDER.md
@@ -1179,6 +1179,18 @@ PR #35 (`dev` -> `main`) をmainへ進めるため、Report Builder取り込み�
   - `app_backend/tests/test_report_storage.py::test_list_by_user_recovers_reports_from_storage_after_new_run`
     - 別run相当の空ローカルキャッシュから、PersistentStorageのindexとmetadataを使って一覧復元できることを確認。
 
+### Sidebar導線改善（2026-06-30）
+
+- 現象: Sidebar上のReport Builder導線がDatasets / Chatsと違う見た目で、ファイルアイコンのみのため見つけづらい。
+- 修正: Sidebarを `Datasets` -> `Chats` -> `Reports` の一連の流れにし、Reportsも同じセクション見出しと `+ New Report` ボタンで表示する。
+- `+ New Report` は `/reports?new=1` に遷移し、Reports画面の作成フォームを開いた状態にする。
+- 既存ReportのSidebar項目には `key` を設定し、クリック時の詳細遷移とactive表示に使えるようにする。
+- 日本語UI向けに `New Report` -> `新しいレポート` の翻訳を追加。
+- 追加テスト:
+  - `app_frontend/tests/components/Sidebar.test.tsx`
+    - feature flagがoffのときReportsとNew Reportを非表示にする。
+    - feature flagがonのとき `Datasets` -> `Chats` -> `Reports` の順に表示し、`New Report` ボタンを表示する。
+
 ---
 
 ## 冗長箇所メモ


### PR DESCRIPTION
## Summary
- Move Report Builder into the sidebar flow as `Datasets -> Chats -> Reports`.
- Replace the icon-only report action with a `+ New Report` button.
- Route `+ New Report` to `/reports?new=1` so the Reports page opens the create form immediately.
- Add a Japanese translation for `New Report`.
- Add Sidebar regression coverage for the feature flag, ordering, and new entrypoint.

## Validation
- `npm run test -- tests/components/Sidebar.test.tsx`
- `npm exec eslint -- src/components/Sidebar.tsx src/pages/Reports.tsx tests/components/Sidebar.test.tsx`
- `npm exec tsc -- -b tsconfig.app.json`
- `npm run test`
- `npm run lint`

## Notes
- `npm run build` reached Vite bundling and failed in this local checkout because Rollup could not resolve `unenv/node/process` from `node_modules/.pnpm/react@19.2.7/node_modules/react/jsx-runtime.js`. TypeScript, lint, and tests passed.