### PR TITLE
[codex] Keep report builder visible below chats

### DIFF
--- a/app_frontend/src/components/Sidebar.tsx
+++ b/app_frontend/src/components/Sidebar.tsx
@@ -49,7 +49,7 @@ const DatasetList = ({ highlight }: { highlight: boolean }) => {
   const navigate = useNavigate();
 
   return (
-    <div className="relative flex h-full flex-1 flex-col">
+    <div className="relative flex max-h-[160px] min-h-0 flex-none flex-col">
       <div className="flex items-center justify-between pb-3 pl-2">
         <div>
           <p className="mn-label-large">{t("Datasets")}</p>
@@ -86,7 +86,10 @@ const ChatList = ({ highlight }: { highlight: boolean }) => {
   const { t } = useTranslation();
 
   return (
-    <div className="relative flex h-full flex-1 flex-col">
+    <div
+      className="relative flex min-h-0 flex-1 flex-col"
+      data-testid="sidebar-chats-section"
+    >
       <div className="flex items-center justify-between pb-3 pl-2">
         <div>
           <p className="mn-label-large">{t("Chats")}</p>
@@ -130,7 +133,10 @@ const ReportList = () => {
     })) || [];
 
   return (
-    <div className="relative flex h-full flex-1 flex-col">
+    <div
+      className="relative flex max-h-[200px] min-h-[92px] flex-none flex-col"
+      data-testid="sidebar-reports-section"
+    >
       <div className="flex items-center justify-between pb-3 pl-2">
         <div>
           <p className="mn-label-large">{t("Reports")}</p>
@@ -202,8 +208,8 @@ export const Sidebar = () => {
             )}
           </p>
         </SidebarHeader>
-        <SidebarContent>
-          <SidebarGroup className="h-full">
+        <SidebarContent className="overflow-hidden">
+          <SidebarGroup className="h-full min-h-0">
             <DatasetList highlight={highlightDatasets} />
             <Separator className="my-6" />
             <ChatList highlight={highlightChats} />

--- a/app_frontend/tests/components/Sidebar.test.tsx
+++ b/app_frontend/tests/components/Sidebar.test.tsx
@@ -94,6 +94,10 @@ describe("Sidebar Report Builder feature flag", () => {
     expect(
       screen.getByRole("button", { name: "New Report" }),
     ).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-chats-section")).toHaveClass("flex-1");
+    expect(screen.getByTestId("sidebar-reports-section")).toHaveClass(
+      "flex-none",
+    );
     expect(
       screen
         .getAllByText(/Datasets|Chats|Reports/)

--- a/customize_docs/new_spec/REPORT_BUILDER.md
+++ b/customize_docs/new_spec/REPORT_BUILDER.md
@@ -1183,6 +1183,7 @@ PR #35 (`dev` -> `main`) をmainへ進めるため、Report Builder取り込み�
 
 - 現象: Sidebar上のReport Builder導線がDatasets / Chatsと違う見た目で、ファイルアイコンのみのため見つけづらい。
 - 修正: Sidebarを `Datasets` -> `Chats` -> `Reports` の一連の流れにし、Reportsも同じセクション見出しと `+ New Report` ボタンで表示する。
+- Chatsの履歴が長い場合でもReportsを必ず表示するため、Sidebar全体ではなくChatsリスト内部だけを伸縮・スクロールさせ、Reportsセクションは固定枠として残す。
 - `+ New Report` は `/reports?new=1` に遷移し、Reports画面の作成フォームを開いた状態にする。
 - 既存ReportのSidebar項目には `key` を設定し、クリック時の詳細遷移とactive表示に使えるようにする。
 - 日本語UI向けに `New Report` -> `新しいレポート` の翻訳を追加。
@@ -1190,6 +1191,7 @@ PR #35 (`dev` -> `main`) をmainへ進めるため、Report Builder取り込み�
   - `app_frontend/tests/components/Sidebar.test.tsx`
     - feature flagがoffのときReportsとNew Reportを非表示にする。
     - feature flagがonのとき `Datasets` -> `Chats` -> `Reports` の順に表示し、`New Report` ボタンを表示する。
+    - Chatsセクションが伸縮領域、Reportsセクションが固定領域であることを確認する。
 
 ---
 


### PR DESCRIPTION
## Summary
- Keep the Reports section visible below Chats even when the chat history is long.
- Make the sidebar content area stop scrolling as one large list; Chats now owns the flexible internal scroll area.
- Keep Reports as a fixed sidebar section with its `+ New Report` action visible.
- Add regression coverage for Chats as the flexible section and Reports as the fixed section.
- Update the Report Builder spec note.

## Validation
- `npm run test -- tests/components/Sidebar.test.tsx`
- `npm exec eslint -- src/components/Sidebar.tsx tests/components/Sidebar.test.tsx`
- `npm exec tsc -- -b tsconfig.app.json`
- `npm run test`
- `npm run lint`

## Notes
- `npm run lint` passes with the existing 4 warnings in unrelated files (`prompt-input.tsx`, `collapsible.tsx`, `sidebar.tsx`, `theme-provider.tsx`).