### PR TITLE
Retry Pulumi frontend dependency install

### DIFF
--- a/.github/workflows/pulumi-up.yml
+++ b/.github/workflows/pulumi-up.yml
@@ -62,6 +62,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: app_frontend/package-lock.json
 
       - name: Install Taskfile
         uses: arduino/setup-task@v2
@@ -82,7 +84,27 @@ jobs:
       - name: Build frontend assets for Pulumi refresh
         working-directory: app_frontend
         run: |
-          npm install
+          set -euo pipefail
+
+          for attempt in 1 2 3; do
+            if npm ci \
+              --no-audit \
+              --fetch-retries=5 \
+              --fetch-retry-factor=2 \
+              --fetch-retry-mintimeout=20000 \
+              --fetch-retry-maxtimeout=120000; then
+              break
+            fi
+
+            if [ "$attempt" = "3" ]; then
+              exit 1
+            fi
+
+            delay=$((attempt * 20))
+            echo "npm ci failed on attempt ${attempt}; retrying in ${delay}s"
+            sleep "$delay"
+          done
+
           npm run build
 
       - name: Restore ApplicationSource files for Pulumi refresh

--- a/customize_docs/pulumi_frontend_build.md
+++ b/customize_docs/pulumi_frontend_build.md
@@ -14,6 +14,13 @@ cleanup 時に `pulumi-resource-command` process が残っていた。
 
 - CI では `SKIP_PULUMI_FRONTEND_BUILD=true` を設定し、Pulumi stack 内の
   `command:local:Command` frontend build resource を作らない。
+- 2026-07-06 の `Pulumi Up` workflow では、Pulumi 実行前の
+  `Build frontend assets for Pulumi refresh` step で `npm install` が `ECONNRESET`
+  により失敗した。
+  - `app_frontend/package-lock.json` を前提に、CI では `npm install` ではなく
+    `npm ci` を使う。
+  - `actions/setup-node` の npm cache を有効化し、registry fetch の一時失敗に備えて
+    `npm ci` を 3 回まで再試行する。
 - workflow の事前 build 成果物を `infra/infra/app_backend.py` の `get_app_backend_app_files()` で直接読む。
 - 既存 Pulumi state に残った `command:local:Command` は update 前に
   stack export JSON から prune し、`pulumi stack import` で反映する。
@@ -45,5 +52,6 @@ cleanup 時に `pulumi-resource-command` process が残っていた。
   - workflow が branch に対応した resource name で App Source / monitoring state を
     事前 prune することを確認する。
   - Pulumi action に `SKIP_PULUMI_FRONTEND_BUILD=true` が渡ることを確認する。
+  - frontend assets build で `npm ci`、npm cache、fetch retry が設定されることを確認する。
 - `customize_docs/test_prune_pulumi_state_resources.py`
   - stack export から対象 type の resources と、その依存参照を削除することを確認する。

--- a/customize_docs/test_pulumi_workflow_refresh.py
+++ b/customize_docs/test_pulumi_workflow_refresh.py
@@ -58,6 +58,13 @@ def test_pulumi_up_workflow_deploys_from_split_infra_project() -> None:
     assert "TEXTGEN_DEPLOYMENT_ID" not in job["env"]
     assert job["env"]["OPENAI_API_KEY"] == "${{ secrets.OPENAI_API_KEY }}"
 
+    node_step = _step_by_name(steps, "Set up Node.js")
+    assert node_step["with"] == {
+        "node-version": "22",
+        "cache": "npm",
+        "cache-dependency-path": "app_frontend/package-lock.json",
+    }
+
     install_step = _step_by_name(steps, "Install infra dependencies")
     assert install_step == {
         "name": "Install infra dependencies",
@@ -72,7 +79,12 @@ def test_pulumi_up_workflow_deploys_from_split_infra_project() -> None:
 
     build_step = _step_by_name(steps, "Build frontend assets for Pulumi refresh")
     assert build_step["working-directory"] == "app_frontend"
-    assert "npm install" in build_step["run"]
+    assert "npm install" not in build_step["run"]
+    assert "for attempt in 1 2 3" in build_step["run"]
+    assert "npm ci" in build_step["run"]
+    assert "--fetch-retries=5" in build_step["run"]
+    assert "--fetch-retry-mintimeout=20000" in build_step["run"]
+    assert "--fetch-retry-maxtimeout=120000" in build_step["run"]
     assert "npm run build" in build_step["run"]
 
     restore_step = _step_by_name(


### PR DESCRIPTION
## Summary
- replace the Pulumi refresh frontend dependency install with lockfile-based `npm ci`
- enable `actions/setup-node` npm cache for `app_frontend/package-lock.json`
- retry `npm ci` up to three times with npm fetch retry settings for transient registry failures
- document the 2026-07-06 `ECONNRESET` failure before Pulumi execution

## Testing
- `uv run pytest customize_docs/test_pulumi_workflow_refresh.py -q`
- `uv run ruff check customize_docs/test_pulumi_workflow_refresh.py`
- `uv run pytest customize_docs/test_pulumi_frontend_build.py customize_docs/test_pulumi_workflow_refresh.py customize_docs/test_prune_pulumi_state_resources.py -q`
- `git diff --check`
- `npm --prefix app_frontend ci --no-audit --fetch-retries=5 --fetch-retry-factor=2 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000`
- `npm --prefix app_frontend run build`
- `yamlfmt -conf .yamlfmt.yml -lint .github/workflows/pulumi-up.yml`

Note: local `yamlfmt -conf .yamlfmt.yml -lint .` scans the generated `app_frontend/node_modules` directory after `npm ci` and fails on a dependency `.travis.yml`; the changed workflow file itself passes yamlfmt.