### PR TITLE
Align Pulumi frontend install with upstream

### DIFF
--- a/.github/workflows/pulumi-up.yml
+++ b/.github/workflows/pulumi-up.yml
@@ -62,8 +62,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
-          cache: npm
-          cache-dependency-path: app_frontend/package-lock.json
 
       - name: Install Taskfile
         uses: arduino/setup-task@v2
@@ -87,7 +85,7 @@ jobs:
           set -euo pipefail
 
           for attempt in 1 2 3; do
-            if npm ci \
+            if npm install \
               --no-audit \
               --fetch-retries=5 \
               --fetch-retry-factor=2 \
@@ -101,7 +99,7 @@ jobs:
             fi
 
             delay=$((attempt * 20))
-            echo "npm ci failed on attempt ${attempt}; retrying in ${delay}s"
+            echo "npm install failed on attempt ${attempt}; retrying in ${delay}s"
             sleep "$delay"
           done
 

--- a/customize_docs/pulumi_frontend_build.md
+++ b/customize_docs/pulumi_frontend_build.md
@@ -17,10 +17,10 @@ cleanup 時に `pulumi-resource-command` process が残っていた。
 - 2026-07-06 の `Pulumi Up` workflow では、Pulumi 実行前の
   `Build frontend assets for Pulumi refresh` step で `npm install` が `ECONNRESET`
   により失敗した。
-  - `app_frontend/package-lock.json` を前提に、CI では `npm install` ではなく
-    `npm ci` を使う。
-  - `actions/setup-node` の npm cache を有効化し、registry fetch の一時失敗に備えて
-    `npm ci` を 3 回まで再試行する。
+  - upstream の frontend workflow と同じく `npm install` を使う。
+  - `app_frontend/package-lock.json` は git 管理されていないため、`npm ci` や
+    `actions/setup-node` の `cache-dependency-path` は使わない。
+  - registry fetch の一時失敗に備えて `npm install` を 3 回まで再試行する。
 - workflow の事前 build 成果物を `infra/infra/app_backend.py` の `get_app_backend_app_files()` で直接読む。
 - 既存 Pulumi state に残った `command:local:Command` は update 前に
   stack export JSON から prune し、`pulumi stack import` で反映する。
@@ -52,6 +52,7 @@ cleanup 時に `pulumi-resource-command` process が残っていた。
   - workflow が branch に対応した resource name で App Source / monitoring state を
     事前 prune することを確認する。
   - Pulumi action に `SKIP_PULUMI_FRONTEND_BUILD=true` が渡ることを確認する。
-  - frontend assets build で `npm ci`、npm cache、fetch retry が設定されることを確認する。
+  - frontend assets build で `npm install` と fetch retry が設定されることを確認する。
+  - git 管理されていない `package-lock.json` に依存する npm cache 設定を入れないことを確認する。
 - `customize_docs/test_prune_pulumi_state_resources.py`
   - stack export から対象 type の resources と、その依存参照を削除することを確認する。

--- a/customize_docs/test_pulumi_workflow_refresh.py
+++ b/customize_docs/test_pulumi_workflow_refresh.py
@@ -59,11 +59,7 @@ def test_pulumi_up_workflow_deploys_from_split_infra_project() -> None:
     assert job["env"]["OPENAI_API_KEY"] == "${{ secrets.OPENAI_API_KEY }}"
 
     node_step = _step_by_name(steps, "Set up Node.js")
-    assert node_step["with"] == {
-        "node-version": "22",
-        "cache": "npm",
-        "cache-dependency-path": "app_frontend/package-lock.json",
-    }
+    assert node_step["with"] == {"node-version": "22"}
 
     install_step = _step_by_name(steps, "Install infra dependencies")
     assert install_step == {
@@ -79,9 +75,10 @@ def test_pulumi_up_workflow_deploys_from_split_infra_project() -> None:
 
     build_step = _step_by_name(steps, "Build frontend assets for Pulumi refresh")
     assert build_step["working-directory"] == "app_frontend"
-    assert "npm install" not in build_step["run"]
+    assert "npm install" in build_step["run"]
+    assert "npm ci" not in build_step["run"]
+    assert "cache-dependency-path" not in build_step["run"]
     assert "for attempt in 1 2 3" in build_step["run"]
-    assert "npm ci" in build_step["run"]
     assert "--fetch-retries=5" in build_step["run"]
     assert "--fetch-retry-mintimeout=20000" in build_step["run"]
     assert "--fetch-retry-maxtimeout=120000" in build_step["run"]


### PR DESCRIPTION
## Summary
- remove `actions/setup-node` npm cache settings that depended on ignored `app_frontend/package-lock.json`
- switch the Pulumi refresh frontend install back to upstream-style `npm install`
- keep retry and npm fetch retry settings for transient registry/network failures
- update workflow contract tests and Pulumi frontend build notes

## Root cause
The previous Pulumi Up run failed before Pulumi executed. `actions/setup-node` could not resolve `app_frontend/package-lock.json` for caching because the lockfile is ignored and not present on GitHub runners.

## Testing
- `uv run pytest customize_docs/test_pulumi_workflow_refresh.py -q`
- `uv run ruff check customize_docs/test_pulumi_workflow_refresh.py`
- `yamlfmt -conf .yamlfmt.yml -lint .github/workflows/pulumi-up.yml`
- `uv run pytest customize_docs/test_pulumi_frontend_build.py customize_docs/test_pulumi_workflow_refresh.py customize_docs/test_prune_pulumi_state_resources.py -q`
- `npm --prefix app_frontend install --no-audit --fetch-retries=5 --fetch-retry-factor=2 --fetch-retry-mintimeout=20000 --fetch-retry-maxtimeout=120000`
- `npm --prefix app_frontend run build`
- `git diff --check`

Note: local Node is v24 and emits an engine warning for i18next-parser; the workflow pins Node 22.