### PR TITLE
Run Docker package install as root

### DIFF
--- a/app_backend/tests/test_dockerfile_runtime_contract.py
+++ b/app_backend/tests/test_dockerfile_runtime_contract.py
@@ -26,6 +26,20 @@ def test_dockerfile_extends_official_context_with_japanese_fonts() -> None:
     assert "python -m pip install --no-cache poetry uv" in dockerfile
 
 
+def test_dockerfile_installs_packages_as_root() -> None:
+    dockerfile_lines = DOCKERFILE.read_text(encoding="utf-8").splitlines()
+    root_line = next(
+        index
+        for index, line in enumerate(dockerfile_lines)
+        if line.strip() == "USER root"
+    )
+    apk_line = next(
+        index for index, line in enumerate(dockerfile_lines) if "apk add" in line
+    )
+
+    assert root_line < apk_line
+
+
 def test_dockerfile_keeps_official_root_runtime_user_contract() -> None:
     dockerfile_lines = DOCKERFILE.read_text(encoding="utf-8").splitlines()
     user_lines = [

--- a/customize_docs/docker_chainguard_japanese_fonts_20260630.md
+++ b/customize_docs/docker_chainguard_japanese_fonts_20260630.md
@@ -42,6 +42,9 @@ DataRobot の Python FIPS dev ベースイメージへ移行するため、Docke
 - PR #117 CI follow-up: hadolint `DL3002 Last USER should not be root` 対応として、Dockerfile の最終実行ユーザーを `65532:65532` に戻したが、これは DataRobot 公式 context / upstream `start-app.sh` の runtime 契約から外れるため再修正対象になった。
 - PR #117 merge 後の dev Pulumi Up は `ExecutionEnvironment` と `ApplicationSource` の作成には成功したが、`CustomApplication` の ready 判定で `application failed to create` になった。DataRobot API の `CustomApplication.get_logs()` では `buildStatus` は success、runtime log は 0 件だったため、Python import ではなく起動スクリプトまたは `uv` bootstrap の前段で失敗した可能性が高い。
 - ユーザー提供の DataRobot 公式 Docker context (`[DataRobot] Python 3.12 Applications Base`) は `USER root` で、`uv` / `poetry` 導入も `python -m pip install --no-cache poetry uv` だった。upstream 追従を最優先するため、`start-app.sh` は upstream と同じ app source 直下 `.uv` / `.venv` 利用へ戻し、Dockerfile も公式 context の root runtime 契約へ戻した。日本語フォント導入だけを追加差分として残す。
+- PR #122 merge 後の dev Pulumi Up は `ExecutionEnvironment` build まで進み、DataRobot build log で `apk add --no-cache fontconfig font-noto-cjk` が `Unable to lock database: Permission denied` で失敗した。
+  - ベースイメージの既定 user は root ではないため、日本語フォントを導入する `apk add` より前に `USER root` を置く必要がある。
+  - runtime の最終 user も DataRobot 公式 context と同じ `root` のまま維持する。
 - `bash -n app_backend/start-app.sh`: 成功。
 - `uv run pytest app_backend/tests/test_dockerfile_runtime_contract.py app_backend/tests/test_v1182_compat.py customize_docs/test_v11_5_3_infra_config.py -q`: 25 passed。
 - `uv run pytest app_backend/tests -q`: 154 passed。LiteLLM の atexit logging warning は出るが pytest は成功。

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 
+USER root
+
 RUN apk add --no-cache fontconfig font-noto-cjk \
     && fc-cache -f
 
@@ -17,7 +19,5 @@ WORKDIR /opt/code
 # Install 'uv' for fast package resolution and 'poetry' for dependency management.
 # This enables support for pyproject.toml based configurations as part of APP-5254.
 RUN python -m pip install --no-cache poetry uv
-
-USER root
 
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- move `USER root` before the Dockerfile `apk add` step
- keep the final runtime user contract as DataRobot official context `root`
- add a Dockerfile contract test for package installation as root
- document the DataRobot execution environment build failure from dev Pulumi

## Root cause
The latest dev Pulumi run reached DataRobot ExecutionEnvironment build and failed while running `apk add --no-cache fontconfig font-noto-cjk`:

```text
ERROR: Unable to lock database: Permission denied
ERROR: Failed to open apk database: Permission denied
```

The base image default user is not root, so package installation must switch to root before the `apk add` layer.

## Testing
- `uv run pytest app_backend/tests/test_dockerfile_runtime_contract.py -q`
- `uv run ruff check app_backend/tests/test_dockerfile_runtime_contract.py`
- `uv run pytest app_backend/tests/test_dockerfile_runtime_contract.py app_backend/tests/test_v1182_compat.py customize_docs/test_v11_5_3_infra_config.py -q`
- `git diff --check`

Not run locally:
- `docker build docker`: Docker daemon socket was unavailable (`/Users/ryosuke.hata/.rd/docker.sock`)
- `hadolint docker/Dockerfile`: hadolint is not installed locally