### PR TITLE
[codex] Fix chat export chart trace normalization

### DIFF
--- a/app_backend/tests/test_schema_pandas_compat.py
+++ b/app_backend/tests/test_schema_pandas_compat.py
@@ -1,9 +1,13 @@
 import asyncio
+import base64
 import io
+import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pandas as pd
 import plotly.graph_objects as go
+import pytest
 from openpyxl import load_workbook
 from utils.analyst_db import DatasetMetadata, DatasetType, InternalDataSourceType
 from utils.schema import (
@@ -61,6 +65,14 @@ def test_chat_excel_export_writes_pandas_analysis_result_sheet() -> None:
     asyncio.run(_assert_chat_excel_export_writes_pandas_analysis_result_sheet())
 
 
+def test_chat_excel_export_writes_problematic_plotly_trace_sheet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asyncio.run(
+        _assert_chat_excel_export_writes_problematic_plotly_trace_sheet(monkeypatch)
+    )
+
+
 def test_run_charts_result_uses_japanese_plotly_font_fallbacks() -> None:
     fig_json = go.Figure(data=[go.Bar(x=["東京", "大阪"], y=[1, 2])]).to_json()
 
@@ -76,6 +88,47 @@ def test_run_charts_result_uses_japanese_plotly_font_fallbacks() -> None:
     assert result.fig1.layout.font.family == expected_family
     assert result.fig2 is not None
     assert result.fig2.layout.font.family == expected_family
+
+
+def test_plotly_trace_export_handles_ragged_arrays_without_pandas_error() -> None:
+    from core.customize.infrastructure.export.chat_export import (
+        plotly_trace_to_dataframe,
+    )
+
+    chart_df = plotly_trace_to_dataframe(
+        {
+            "type": "bar",
+            "x": ["FY2025", "FY2026"],
+            "y": [100],
+        }
+    )
+
+    assert chart_df["x"].to_list() == ["FY2025", "FY2026"]
+    assert chart_df.loc[0, "y"] == 100
+    assert pd.isna(chart_df.loc[1, "y"])
+
+
+def test_plotly_trace_export_ignores_nested_style_dicts_without_pandas_error() -> None:
+    from core.customize.infrastructure.export.chat_export import (
+        plotly_trace_to_dataframe,
+    )
+
+    chart_df = plotly_trace_to_dataframe(
+        {
+            "type": "scatter",
+            "x": ["A", "B"],
+            "y": [10, 20],
+            "line": {"color": "red"},
+            "marker": {"size": [4, 8]},
+        }
+    )
+
+    assert chart_df.to_dict("records") == [
+        {"x": "A", "y": 10},
+        {"x": "B", "y": 20},
+    ]
+    assert "line" not in chart_df.columns
+    assert "marker" not in chart_df.columns
 
 
 async def _assert_chat_excel_export_writes_pandas_analysis_result_sheet() -> None:
@@ -100,6 +153,47 @@ async def _assert_chat_excel_export_writes_pandas_analysis_result_sheet() -> Non
     assert data_sheet["B1"].value == "label"
     assert data_sheet["A2"].value == 10
     assert data_sheet["B2"].value == "A"
+
+
+async def _assert_chat_excel_export_writes_problematic_plotly_trace_sheet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core.routers.chats import save_chat_messages
+
+    def write_tiny_png(
+        self: go.Figure,
+        file: str | Path,
+        *_args: object,
+        **_kwargs: object,
+    ) -> None:
+        png_data = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+        )
+        Path(file).write_bytes(png_data)
+
+    monkeypatch.setattr(go.Figure, "write_image", write_tiny_png)
+
+    response = await save_chat_messages(
+        request=None,  # type: ignore[arg-type]
+        chat_id="chat-1",
+        analyst_db=_FakeChartAnalystDB(),  # type: ignore[arg-type]
+    )
+    chunks: list[bytes] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk if isinstance(chunk, bytes) else chunk.encode("utf-8"))
+    if response.background:
+        await response.background()
+    body = b"".join(chunks)
+    workbook = load_workbook(io.BytesIO(body), read_only=True)
+
+    assert "Chart 1" in workbook.sheetnames
+    chart_sheet = workbook["Chart 1"]
+    assert chart_sheet["A1"].value == "x"
+    assert chart_sheet["B1"].value == "y"
+    assert chart_sheet["A2"].value == "FY2025"
+    assert chart_sheet["B2"].value == 100
+    assert chart_sheet["A3"].value == "FY2026"
+    assert chart_sheet["A1"].value != "Chart Processing Error"
 
 
 class _FakeDatasetHandler:
@@ -156,6 +250,46 @@ class _FakeAnalystDB:
                             attempts=1,
                             datasets_analyzed=1,
                         ),
+                    )
+                ],
+                in_progress=False,
+            ),
+        ]
+
+
+class _FakeChartAnalystDB:
+    async def get_chat_messages(self, chat_id: str) -> list[AnalystChatMessage]:
+        assert chat_id == "chat-1"
+        fig_json = json.dumps(
+            {
+                "data": [
+                    {
+                        "type": "scatter",
+                        "x": ["FY2025", "FY2026"],
+                        "y": [100],
+                        "line": {"color": "red"},
+                    }
+                ],
+                "layout": {},
+            }
+        )
+        return [
+            AnalystChatMessage(
+                id="user-1",
+                role="user",
+                content="plot revenue",
+                components=[],
+                in_progress=False,
+            ),
+            AnalystChatMessage(
+                id="assistant-1",
+                role="assistant",
+                content="chart",
+                components=[
+                    RunChartsResult(
+                        status="success",
+                        fig1_json=fig_json,
+                        metadata=RunAnalysisResultMetadata(duration=0, attempts=1),
                     )
                 ],
                 in_progress=False,

--- a/core/src/core/customize/infrastructure/export/__init__.py
+++ b/core/src/core/customize/infrastructure/export/__init__.py
@@ -1,0 +1,9 @@
+"""
+Infrastructure Layer - Export
+
+Excel export adapters and serialization helpers.
+"""
+
+from core.customize.infrastructure.export.chat_export import plotly_trace_to_dataframe
+
+__all__ = ["plotly_trace_to_dataframe"]

--- a/core/src/core/customize/infrastructure/export/chat_export.py
+++ b/core/src/core/customize/infrastructure/export/chat_export.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+_PLOTLY_TRACE_METADATA_FIELDS = frozenset({"type", "name"})
+
+
+def plotly_trace_to_dataframe(trace: Mapping[str, Any]) -> pd.DataFrame:
+    """Convert a Plotly trace dict into tabular rows safe for Excel export."""
+    columns: dict[str, list[Any]] = {}
+
+    for key, value in trace.items():
+        if key in _PLOTLY_TRACE_METADATA_FIELDS:
+            continue
+
+        column_values = _as_column_values(value)
+        if column_values is None:
+            continue
+
+        columns[key] = [_to_excel_cell_value(item) for item in column_values]
+
+    if not columns:
+        return pd.DataFrame()
+
+    column_names = list(columns)
+    row_count = max(len(values) for values in columns.values())
+    records = [
+        {
+            column_name: (
+                columns[column_name][row_index]
+                if row_index < len(columns[column_name])
+                else None
+            )
+            for column_name in column_names
+        }
+        for row_index in range(row_count)
+    ]
+
+    return pd.DataFrame.from_records(records, columns=column_names)
+
+
+def _as_column_values(value: Any) -> list[Any] | None:
+    if isinstance(value, Mapping):
+        return _decode_plotly_typed_array(value)
+
+    if isinstance(value, (str, bytes, bytearray)):
+        return None
+
+    if isinstance(value, Sequence):
+        return list(value)
+
+    return None
+
+
+def _decode_plotly_typed_array(value: Mapping[str, Any]) -> list[Any] | None:
+    dtype = value.get("dtype")
+    encoded_data = value.get("bdata")
+
+    if not isinstance(dtype, str) or not isinstance(encoded_data, str):
+        return None
+
+    try:
+        array = np.frombuffer(base64.b64decode(encoded_data), dtype=np.dtype(dtype))
+    except (TypeError, ValueError, binascii.Error):
+        return None
+
+    shape = _parse_plotly_array_shape(value.get("shape"))
+    if shape:
+        try:
+            array = array.reshape(shape)
+        except ValueError:
+            pass
+
+    return array.tolist()
+
+
+def _parse_plotly_array_shape(shape: Any) -> tuple[int, ...] | None:
+    if isinstance(shape, str):
+        try:
+            return tuple(int(part.strip()) for part in shape.split(",") if part.strip())
+        except ValueError:
+            return None
+
+    if isinstance(shape, Sequence) and not isinstance(shape, (str, bytes, bytearray)):
+        try:
+            return tuple(int(part) for part in shape)
+        except (TypeError, ValueError):
+            return None
+
+    return None
+
+
+def _to_excel_cell_value(value: Any) -> Any:
+    if isinstance(value, (Mapping, list, tuple)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+    return value

--- a/core/src/core/routers/chats.py
+++ b/core/src/core/routers/chats.py
@@ -22,7 +22,6 @@ import os
 import tempfile
 from typing import Any, List, Union, cast
 
-import pandas as pd
 from datarobot_genai.core.utils.token_tracking import (
     HeuristicTokenCountingStrategy,
     TokenUsageTracker,
@@ -51,6 +50,7 @@ from core.constants import (
     CONTEXT_WARNING_THRESHOLD,
     MODEL_CONTEXT_WINDOW,
 )
+from core.customize.infrastructure.export.chat_export import plotly_trace_to_dataframe
 from core.deps import get_initialized_db
 from core.logging_helper import get_logger
 from core.schema import (
@@ -761,9 +761,7 @@ async def save_chat_messages(
                         parsed_json = json.loads(js)
                         data_list = parsed_json.get("data", [])
                         if data_list and len(data_list) > 0:
-                            fig_json = data_list[0].copy()
-                            [fig_json.pop(k, None) for k in ["marker", "name", "type"]]
-                            chart_df = pd.DataFrame(fig_json)
+                            chart_df = plotly_trace_to_dataframe(data_list[0])
                             for r in dataframe_to_rows(
                                 chart_df, index=False, header=True
                             ):

--- a/customize_docs/chat_export_plotly_trace_fix_20260706.md
+++ b/customize_docs/chat_export_plotly_trace_fix_20260706.md
@@ -1,0 +1,45 @@
+# Chat Export Plotly Trace Fix
+
+## 背景
+
+チャットをExcelエクスポートすると、チャートデータシートに以下の pandas 例外が出ることがあった。
+
+- `Error: All arrays must be of the same length`
+- `Error: Mixing dicts with non-Series may lead to ambiguous ordering.`
+
+## 原因
+
+`core/src/core/routers/chats.py` のチャートエクスポート処理で、Plotly figure JSON の trace dict をほぼそのまま `pd.DataFrame(...)` に渡していた。
+
+Plotly trace には `x` / `y` のような配列データだけでなく、`line` / `marker` のような入れ子dict、`type` / `name` のようなメタデータ、長さが揃わない配列が含まれることがある。そのため pandas の列形式DataFrame生成条件に合わず、上記例外が発生していた。
+
+## 改善方針
+
+pandas 公式ドキュメント上も、列形式の dict は配列長が揃った表形式データ向けであり、Plotly trace 全体のJSON構造を直接渡す用途ではない。チャートエクスポートでは以下の正規化を行う。
+
+- trace の配列値だけをExcel向けの列として扱う
+- `type` / `name` などのメタデータと、`line` / `marker` などの入れ子dictは表データから除外する
+- 配列長が揃わない場合は最大長に合わせ、不足分は空セルにする
+- Plotly typed array JSON (`dtype` / `bdata`) は配列へ復元できる場合だけ列化する
+- DataFrame作成は `DataFrame.from_records(...)` に渡せる行レコードへ変換してから行う
+
+## 変更内容
+
+- `core.customize.infrastructure.export.chat_export.plotly_trace_to_dataframe()` を追加
+- `core/src/core/routers/chats.py` のチャートデータシート生成で、trace dict の直接DataFrame化を廃止
+
+## テスト
+
+追加・確認したテスト:
+
+- 長さの違う `x/y` 配列を持つPlotly traceで pandas 例外が出ず、不足分が空値になること
+- `line` / `marker` のような入れ子dictを持つPlotly traceで pandas 例外が出ず、表データ列だけが出力されること
+- 実際のチャットExcelエクスポート関数で、問題のあるPlotly traceが `Chart Processing Error` ではなく `Chart 1` シートとして出力されること
+
+実行コマンド:
+
+```bash
+uv run pytest app_backend/tests/test_schema_pandas_compat.py -q
+uv run pytest app_backend/tests -q
+uv run ruff check core/src/core/customize/infrastructure/export/chat_export.py core/src/core/customize/infrastructure/export/__init__.py core/src/core/routers/chats.py app_backend/tests/test_schema_pandas_compat.py
+```


### PR DESCRIPTION
## Summary

- Normalize Plotly trace JSON before writing chart data sheets in chat Excel exports.
- Avoid passing ragged arrays or nested style dictionaries directly into `pd.DataFrame(...)`.
- Add regression coverage for the two pandas export errors and document the fix under `customize_docs`.

## Root Cause

The export route treated a Plotly trace dict as column-oriented DataFrame input. Plotly trace JSON can mix row arrays (`x`, `y`), metadata (`type`, `name`), nested style dictionaries (`line`, `marker`), and arrays with different lengths. That shape can trigger pandas errors such as `All arrays must be of the same length` or `Mixing dicts with non-Series may lead to ambiguous ordering`.

## Validation

- `uv run pytest app_backend/tests/test_schema_pandas_compat.py -q`
- `uv run pytest app_backend/tests -q` (`158 passed`; existing litellm atexit logging warnings appeared after success)
- `uv run ruff check core/src/core/customize/domain/chat_export.py utils/customize/domain/chat_export.py core/src/core/routers/chats.py app_backend/tests/test_schema_pandas_compat.py`
