### PR TITLE
Pass session secret to Pulumi workflow

### DIFF
--- a/.github/workflows/pulumi-up.yml
+++ b/.github/workflows/pulumi-up.yml
@@ -37,6 +37,7 @@ jobs:
       OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
       OPENAI_API_VERSION: ${{ secrets.OPENAI_API_VERSION }}
       OPENAI_API_DEPLOYMENT_ID: ${{ secrets.OPENAI_API_DEPLOYMENT_ID }}
+      SESSION_SECRET_KEY: ${{ secrets.SESSION_SECRET_KEY }}
       FRONTEND_TYPE: ${{ vars.FRONTEND_TYPE || 'react' }}
       APPLICATION_EXECUTION_ENVIRONMENT_ID: ${{ github.ref == 'refs/heads/main' && secrets.APPLICATION_EXECUTION_ENVIRONMENT_ID
         || '' }}

--- a/customize_docs/test_v11_10_2_integration.py
+++ b/customize_docs/test_v11_10_2_integration.py
@@ -77,12 +77,19 @@ def test_app_backend_targets_python_312_runtime() -> None:
 def test_session_secret_runtime_parameter_is_declared_for_cli_and_infra() -> None:
     cli_config = (REPO_ROOT / ".datarobot" / "cli" / "app_backend.yaml").read_text()
     infra_source = (REPO_ROOT / "infra" / "infra" / "app_backend.py").read_text()
+    pulumi_workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "pulumi-up.yml").read_text()
+    )
 
     assert "env: SESSION_SECRET_KEY" in cli_config
     assert "generate: true" in cli_config
     assert 'key="SESSION_SECRET_KEY"' in infra_source
     assert "datarobot.ApiTokenCredential" in infra_source
     assert "pulumi_datarobot.ApiTokenCredential" not in infra_source
+    assert (
+        pulumi_workflow["jobs"]["update"]["env"]["SESSION_SECRET_KEY"]
+        == "${{ secrets.SESSION_SECRET_KEY }}"
+    )
 
 
 def test_test_user_email_is_scoped_to_dev_task_only() -> None:

--- a/customize_docs/v11_10_2_integration_plan.md
+++ b/customize_docs/v11_10_2_integration_plan.md
@@ -35,6 +35,7 @@
 - `TEST_USER_EMAIL` は dev server 専用のローカル開発用値なので、Taskfile の top-level env には置かず `tasks.dev.env` に限定する。これにより `task test` や deployed instance の import path に `TEST_USER_EMAIL` が漏れない。
 - app factory tests は upstream の session middleware 初期化に必要な `SESSION_SECRET_KEY` を明示する。
 - LLM client の unit test は `Config()` を fake に差し替え、ローカルの `.env` / `pulumi_config.json` にある LLM runtime parameter が upstream default model の検証を上書きしないようにする。実装側は引き続き DataRobot settings fallback を尊重する。
+- `pulumi-up.yml` は `SESSION_SECRET_KEY` を GitHub Actions secret から Pulumi env に渡す。secret値はリポジトリに置かず、GitHub Secret `SESSION_SECRET_KEY` として管理する。
 
 ## Tests
 
@@ -50,6 +51,7 @@
 - `uv run pytest customize_docs/test_v11_10_2_integration.py app_backend/tests/test_v1151_fastapi_app_factory.py app_backend/tests/test_v1151_fastapi_integration.py app_backend/tests/test_main.py app_backend/tests/test_v1150_compat.py -q`: 24 passed
 - `uv run ruff check app_backend/tests/test_llm_client.py app_backend/tests/test_v1151_fastapi_app_factory.py customize_docs/test_v11_10_2_integration.py`: passed
 - `task --dir app_backend test`: 160 passed, 1 warning
+- `uv run pytest customize_docs/test_v11_10_2_integration.py -q`: 5 passed
 
 補足:
 
@@ -58,3 +60,4 @@
 - backend config test はローカル `.env` / DataRobot settings 由来の OTel endpoint/header 補完を受けたため、`otel_sdk_disabled=""` の coercion 確認に必要な OTel fields を明示的に空へ固定した。
 - `npm --prefix app_frontend run build` は既存の Browserslist stale data と大きい chunk warning を出したが、終了コードは 0。
 - CI failure 調査では、`TEST_USER_EMAIL` が `task test` にも漏れて deployed instance guard に引っかかったこと、app factory tests が `SESSION_SECRET_KEY` を設定していなかったことを確認した。ローカル full backend test では追加で `pulumi_config.json` の LLM fallback による unit test 非決定性も検出し、test isolation を追加した。
+- dev merge 後の Pulumi Up failure は `SESSION_SECRET_KEY environment variable is required to deploy app_backend`。workflow env に `SESSION_SECRET_KEY` がなかったため、GitHub Secret が設定されていても Pulumi program に渡らない状態だった。


### PR DESCRIPTION
## Summary
- pass SESSION_SECRET_KEY from GitHub Actions secrets into the Pulumi Up workflow
- add characterization coverage for the workflow env wiring
- record the Pulumi failure cause in v11.10.2 integration notes

## Testing
- uv run pytest customize_docs/test_v11_10_2_integration.py -q
- uv run ruff check customize_docs/test_v11_10_2_integration.py
- yamlfmt -conf .yamlfmt.yml -lint .github/workflows/pulumi-up.yml

## Ops
- Added repo secret SESSION_SECRET_KEY via gh secret set. The value was randomly generated and not written to the repository.