### PR TITLE
Document Snowflake env template values

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,6 +7,9 @@
 # Required, unless logged in to pulumi cloud. Choose your own alphanumeric passphrase to be used for encrypting pulumi config
 PULUMI_CONFIG_PASSPHRASE=1234abc
 
+# Required for FastAPI session cookies and Pulumi deployments.
+# `dr dotenv setup` generates this automatically; for manual setup, use a long random string.
+# SESSION_SECRET_KEY=<long_random_string>
 
 # If empty, a new use case will be created
 DATAROBOT_DEFAULT_USE_CASE=
@@ -138,12 +141,41 @@ USE_DATAROBOT_LLM_GATEWAY=
 #   jdbc:bigquery://     — BigQuery
 #
 # JDBC_URI=jdbc:postgresql://localhost:5432/mydb
-# JDBC_URI=jdbc:snowflake://account.snowflakecomputing.com/?warehouse=WH&db=DB&schema=PUBLIC
+# JDBC_URI=jdbc:snowflake://<account_identifier>.snowflakecomputing.com/?warehouse=COMPUTE_WH&db=SNOWFLAKE_SAMPLE_DATA&schema=TPCH_SF1&role=PUBLIC
 # JDBC_URI=jdbc:sap://host:443
 # JDBC_URI=jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443
 #
 # JDBC_CONNECTION_PARAMETERS is optional. The value must be valid JSON.
 # JDBC_CONNECTION_PARAMETERS='{"user": "dbuser", "password": "secret"}'
+# Snowflake JDBC examples:
+# JDBC_CONNECTION_PARAMETERS='{"user": "snowflake_user", "password": "snowflake_password"}'
+# JDBC_CONNECTION_PARAMETERS='{"user": "snowflake_user", "private_key_file": "rsa_key.p8"}'
+#
+# Legacy Snowflake variables kept for local compatibility paths.
+# DATABASE_CONNECTION_TYPE=snowflake
+#
+# Choose which authentication method to use for Snowflake.
+# snowflake_authentication="key file authentication"
+#
+# SNOWFLAKE_USER="<snowflake_user>"
+# SNOWFLAKE_PASSWORD="<snowflake_password>"
+# The Snowflake key path
+# SNOWFLAKE_KEY_PATH="rsa_key.p8"
+#
+# The Snowflake account
+# SNOWFLAKE_ACCOUNT="<account_identifier>"
+#
+# The Snowflake warehouse
+# SNOWFLAKE_WAREHOUSE="COMPUTE_WH"
+#
+# The Snowflake database
+# SNOWFLAKE_DATABASE="SNOWFLAKE_SAMPLE_DATA"
+#
+# The Snowflake schema
+# SNOWFLAKE_SCHEMA="TPCH_SF1"
+#
+# The Snowflake role
+# SNOWFLAKE_ROLE="PUBLIC"
 
 # Frontend Feature Flags
 

--- a/customize_docs/test_v11_10_2_integration.py
+++ b/customize_docs/test_v11_10_2_integration.py
@@ -76,11 +76,13 @@ def test_app_backend_targets_python_312_runtime() -> None:
 
 def test_session_secret_runtime_parameter_is_declared_for_cli_and_infra() -> None:
     cli_config = (REPO_ROOT / ".datarobot" / "cli" / "app_backend.yaml").read_text()
+    env_template = (REPO_ROOT / ".env.template").read_text()
     infra_source = (REPO_ROOT / "infra" / "infra" / "app_backend.py").read_text()
     pulumi_workflow = yaml.safe_load(
         (REPO_ROOT / ".github" / "workflows" / "pulumi-up.yml").read_text()
     )
 
+    assert "SESSION_SECRET_KEY=<long_random_string>" in env_template
     assert "env: SESSION_SECRET_KEY" in cli_config
     assert "generate: true" in cli_config
     assert 'key="SESSION_SECRET_KEY"' in infra_source
@@ -97,3 +99,25 @@ def test_test_user_email_is_scoped_to_dev_task_only() -> None:
 
     assert "TEST_USER_EMAIL" not in taskfile.get("env", {})
     assert taskfile["tasks"]["dev"]["env"]["TEST_USER_EMAIL"] == "dev@example.com"
+
+
+def test_env_template_documents_snowflake_values() -> None:
+    env_template = (REPO_ROOT / ".env.template").read_text()
+
+    assert "jdbc:snowflake://<account_identifier>.snowflakecomputing.com/" in (
+        env_template
+    )
+    assert "SNOWFLAKE_SAMPLE_DATA" in env_template
+    assert "TPCH_SF1" in env_template
+    for expected in (
+        'snowflake_authentication="key file authentication"',
+        'SNOWFLAKE_USER="<snowflake_user>"',
+        'SNOWFLAKE_PASSWORD="<snowflake_password>"',
+        'SNOWFLAKE_KEY_PATH="rsa_key.p8"',
+        'SNOWFLAKE_ACCOUNT="<account_identifier>"',
+        'SNOWFLAKE_WAREHOUSE="COMPUTE_WH"',
+        'SNOWFLAKE_DATABASE="SNOWFLAKE_SAMPLE_DATA"',
+        'SNOWFLAKE_SCHEMA="TPCH_SF1"',
+        'SNOWFLAKE_ROLE="PUBLIC"',
+    ):
+        assert expected in env_template

--- a/customize_docs/v11_10_2_integration_plan.md
+++ b/customize_docs/v11_10_2_integration_plan.md
@@ -36,12 +36,14 @@
 - app factory tests は upstream の session middleware 初期化に必要な `SESSION_SECRET_KEY` を明示する。
 - LLM client の unit test は `Config()` を fake に差し替え、ローカルの `.env` / `pulumi_config.json` にある LLM runtime parameter が upstream default model の検証を上書きしないようにする。実装側は引き続き DataRobot settings fallback を尊重する。
 - `pulumi-up.yml` は `SESSION_SECRET_KEY` を GitHub Actions secret から Pulumi env に渡す。secret値はリポジトリに置かず、GitHub Secret `SESSION_SECRET_KEY` として管理する。
+- `.env.template` は手動セットアップ向けに `SESSION_SECRET_KEY=<long_random_string>` をコメント付きで案内する。空値を active にすると空の session secret として扱われる恐れがあるため、placeholder はコメントアウトしておく。
+- `.env.template` は Snowflake 用に `jdbc:snowflake://...` の具体例と `SNOWFLAKE_*` placeholder を併記する。実値は環境固有のためテンプレートには入れない。
 
 ## Tests
 
 実施済み:
 
-- `uv run pytest customize_docs/test_v11_10_2_integration.py -q`: 5 passed
+- `uv run pytest customize_docs/test_v11_10_2_integration.py -q`: 6 passed
 - `uv run --project core pytest core/tests/test_v1182_core.py -q`: 21 passed, 3 warnings
 - `uv run pytest app_backend/tests/test_v1151_fastapi_integration.py app_backend/tests/test_v1153_backend_compat.py app_backend/tests/test_v1182_compat.py app_backend/tests/test_upstream_compat_imports.py -q`: 37 passed
 - `uv run ruff check app_backend/app/__init__.py app_backend/app/config.py app_backend/app/profiling.py app_backend/tests/test_v1151_fastapi_integration.py app_backend/tests/test_v1153_backend_compat.py app_backend/tests/test_v1182_compat.py core/src/core/data_cleansing_helpers.py infra/infra/app_backend.py customize_docs/test_v11_10_2_integration.py`: passed


### PR DESCRIPTION
## Summary
- add SESSION_SECRET_KEY guidance to .env.template
- expand Snowflake JDBC examples with sample database/schema/role values
- add legacy SNOWFLAKE_* placeholder block for local compatibility paths

## Testing
- uv run pytest customize_docs/test_v11_10_2_integration.py -q
- uv run ruff check customize_docs/test_v11_10_2_integration.py

## Notes
- Kept Snowflake username/account as placeholders instead of committing environment-specific values.