### PR TITLE
Add Snowflake legacy JDBC compatibility

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -86,13 +86,18 @@ USE_BUILDER_API_TOKEN=false
 # Use LLM Gateway instead of DataRobot-hosted LLM.
 USE_DATAROBOT_LLM_GATEWAY=
 
+# Required: Random string for Web application security. We recommend a long password generated securely such as:
+# `python -c "import os, binascii; print(binascii.hexlify(os.urandom(64)).decode('utf-8'))"`
+SESSION_SECRET_KEY=
+
+
 # To use an existing TextGen Model or Deployment:
 #  1. Provide exactly one of: registered model ID, or deployment ID 
 #  2. Set CHAT_MODEL_NAME to the model name expected by the TextGen model (e.g. gpt-4o-mini)
 #  3. Set LLM=LLMs.DEPLOYED_LLM in infra/settings_generative.py
 
 # TEXTGEN_REGISTERED_MODEL_ID=
-# TEXTGEN_DEPLOYMENT_ID=
+# LLM_DEPLOYMENT_ID=
 # CHAT_MODEL_NAME=datarobot-deployed-llm # for NIM models, "datarobot-deployed-llm" will automatically be translated to the correct model name.
 
 # Set up DataRobot-hosted LLM deployment (make sure to comment and unset OPENAI_* variables if you want to use DataRobot LLM Gateway)
@@ -149,9 +154,14 @@ USE_DATAROBOT_LLM_GATEWAY=
 # JDBC_CONNECTION_PARAMETERS='{"user": "dbuser", "password": "secret"}'
 # Snowflake JDBC examples:
 # JDBC_CONNECTION_PARAMETERS='{"user": "snowflake_user", "password": "snowflake_password"}'
-# JDBC_CONNECTION_PARAMETERS='{"user": "snowflake_user", "private_key_file": "rsa_key.p8"}'
+# For direct JDBC configuration, pass key content as private_key_base64.
+# Local private_key_file paths are not readable by DataRobot JDBC Preview.
+# JDBC_CONNECTION_PARAMETERS='{"user": "snowflake_user", "private_key_base64": "<base64_encoded_pem_private_key>"}'
 #
-# Legacy Snowflake variables kept for local compatibility paths.
+# Legacy Snowflake variables kept for compatibility.
+# When DATABASE_CONNECTION_TYPE=snowflake and JDBC_URI is empty, these values are
+# converted to an equivalent Snowflake JDBC_URI and JDBC_CONNECTION_PARAMETERS.
+# SNOWFLAKE_KEY_PATH is read locally during deployment and converted to private_key_base64.
 # DATABASE_CONNECTION_TYPE=snowflake
 #
 # Choose which authentication method to use for Snowflake.

--- a/app_backend/tests/test_v1182_compat.py
+++ b/app_backend/tests/test_v1182_compat.py
@@ -58,6 +58,9 @@ def test_infra_maps_jdbc_credentials_and_otel_runtime_parameters() -> None:
     credential_source = (
         REPO_ROOT / "infra" / "infra" / "components" / "dr_credential.py"
     ).read_text()
+    database_source = (
+        REPO_ROOT / "core" / "src" / "core" / "database_helpers.py"
+    ).read_text()
 
     assert "OTEL_EXPORTER_OTLP_ENDPOINT" in app_backend_source
     assert "OTEL_EXPORTER_OTLP_HEADERS" in app_backend_source
@@ -65,6 +68,8 @@ def test_infra_maps_jdbc_credentials_and_otel_runtime_parameters() -> None:
     assert "JDBCCredentials" in credential_source
     assert "JDBC_URI" in credential_source
     assert "JDBC_CONNECTION_PARAMETERS" in credential_source
+    assert "core.customize.snowflake_jdbc_compat" in credential_source
+    assert "core.customize.snowflake_jdbc_compat" in database_source
 
 
 def test_infra_uses_upstream_execution_environment_selector() -> None:

--- a/core/src/core/customize/snowflake_jdbc_compat.py
+++ b/core/src/core/customize/snowflake_jdbc_compat.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+from urllib.parse import urlencode
+
+from pydantic import ValidationError
+
+from core.credentials import JDBCCredentials, SnowflakeCredentials
+
+
+def _explicit_jdbc_uri_configured() -> bool:
+    return bool(os.getenv("JDBC_URI") or os.getenv("MLOPS_RUNTIME_PARAM_JDBC_URI"))
+
+
+def _snowflake_account_host(account: str) -> str:
+    host = account.strip()
+    for prefix in ("jdbc:snowflake://", "https://", "http://"):
+        if host.startswith(prefix):
+            host = host.removeprefix(prefix)
+            break
+    host = host.split("?", maxsplit=1)[0].rstrip("/")
+    if host.endswith(".snowflakecomputing.com"):
+        return host
+    return f"{host}.snowflakecomputing.com"
+
+
+def _snowflake_legacy_connection_parameters(
+    credentials: SnowflakeCredentials,
+) -> dict[str, str]:
+    parameters: dict[str, str] = {}
+    if credentials.user:
+        parameters["user"] = credentials.user
+
+    if credentials.snowflake_key_path:
+        if private_key_file := _read_snowflake_private_key_file(credentials):
+            parameters["private_key_base64"] = base64.b64encode(
+                private_key_file
+            ).decode("ascii")
+            if credentials.password:
+                parameters["private_key_pwd"] = credentials.password
+    elif credentials.password:
+        parameters["password"] = credentials.password
+
+    return parameters
+
+
+def _private_key_project_roots() -> tuple[Path, ...]:
+    repo_root = Path(__file__).resolve().parents[4]
+    cwd = Path.cwd()
+    return (cwd, cwd.parent, repo_root)
+
+
+def _read_snowflake_private_key_file(
+    credentials: SnowflakeCredentials,
+) -> bytes | None:
+    if not credentials.snowflake_key_path:
+        return None
+
+    key_path = Path(credentials.snowflake_key_path)
+    for project_root in _private_key_project_roots():
+        resolved_path = key_path if key_path.is_absolute() else project_root / key_path
+        if resolved_path.exists():
+            return resolved_path.read_bytes()
+    return None
+
+
+def snowflake_jdbc_credentials_from_legacy_env() -> JDBCCredentials | None:
+    """Build JDBC credentials from legacy Snowflake env vars when JDBC_URI is absent."""
+    if _explicit_jdbc_uri_configured():
+        return None
+
+    try:
+        snowflake_credentials = SnowflakeCredentials()
+    except ValidationError:
+        return None
+
+    if not snowflake_credentials.is_configured():
+        return None
+
+    query_params = {
+        "warehouse": snowflake_credentials.warehouse,
+        "db": snowflake_credentials.database,
+        "schema": snowflake_credentials.db_schema,
+        "role": snowflake_credentials.role,
+    }
+    jdbc_uri = (
+        f"jdbc:snowflake://{_snowflake_account_host(snowflake_credentials.account)}/"
+        f"?{urlencode(query_params)}"
+    )
+    return JDBCCredentials.model_validate(
+        {
+            "JDBC_URI": jdbc_uri,
+            "JDBC_CONNECTION_PARAMETERS": _snowflake_legacy_connection_parameters(
+                snowflake_credentials
+            ),
+        }
+    )

--- a/core/src/core/database_helpers.py
+++ b/core/src/core/database_helpers.py
@@ -46,6 +46,9 @@ from core.credentials import (
 from core.customize.prompts import (
     SYSTEM_PROMPT_SNOWFLAKE,
 )
+from core.customize.snowflake_jdbc_compat import (
+    snowflake_jdbc_credentials_from_legacy_env,
+)
 from core.logging_helper import get_logger
 from core.prompts import (
     SYSTEM_PROMPT_BIGQUERY,
@@ -1320,6 +1323,10 @@ def get_database_operator(
         try:
             return JdbcPreviewOperator(JDBCCredentials(), schema=schema)
         except (ValidationError, ValueError) as exc:
+            if app_infra.database == "snowflake":
+                credentials = snowflake_jdbc_credentials_from_legacy_env()
+                if credentials is not None:
+                    return JdbcPreviewOperator(credentials, schema=schema)
             raise ValueError(
                 f"DATABASE_CONNECTION_TYPE is '{app_infra.database}' but JDBC_URI "
                 "is missing or invalid. Set JDBC_URI to a valid JDBC connection "

--- a/core/tests/test_v1182_core.py
+++ b/core/tests/test_v1182_core.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -16,6 +17,22 @@ from core.schema import (
     RunAnalysisResultMetadata,
 )
 from core.telemetry.otel import OTel, OTLPConnectionErrorFilter
+
+_SNOWFLAKE_ENV_VARS = (
+    "SNOWFLAKE_USER",
+    "SNOWFLAKE_PASSWORD",
+    "SNOWFLAKE_ACCOUNT",
+    "SNOWFLAKE_WAREHOUSE",
+    "SNOWFLAKE_DATABASE",
+    "SNOWFLAKE_SCHEMA",
+    "SNOWFLAKE_ROLE",
+    "SNOWFLAKE_KEY_PATH",
+)
+
+
+def _clear_snowflake_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env_var in _SNOWFLAKE_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
 
 
 @pytest.fixture(autouse=True)
@@ -198,9 +215,80 @@ def test_platform_database_types_require_jdbc_uri(
 ) -> None:
     monkeypatch.delenv("JDBC_URI", raising=False)
     monkeypatch.delenv("JDBC_CONNECTION_PARAMETERS", raising=False)
+    _clear_snowflake_env(monkeypatch)
 
     with pytest.raises(ValueError, match="JDBC_URI"):
         get_database_operator(AppInfra(llm="llm", database=database))
+
+
+def test_snowflake_legacy_env_values_build_jdbc_preview_operator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JDBC_URI", raising=False)
+    monkeypatch.delenv("JDBC_CONNECTION_PARAMETERS", raising=False)
+    _clear_snowflake_env(monkeypatch)
+    monkeypatch.setenv("SNOWFLAKE_USER", "snowflake_user")
+    monkeypatch.setenv("SNOWFLAKE_PASSWORD", "snowflake_password")
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "account")
+    monkeypatch.setenv("SNOWFLAKE_WAREHOUSE", "COMPUTE_WH")
+    monkeypatch.setenv("SNOWFLAKE_DATABASE", "ANALYTICS")
+    monkeypatch.setenv("SNOWFLAKE_SCHEMA", "PUBLIC")
+    monkeypatch.setenv("SNOWFLAKE_ROLE", "ANALYST")
+
+    operator = get_database_operator(AppInfra(llm="llm", database="snowflake"))
+
+    assert isinstance(operator, JdbcPreviewOperator)
+    assert (
+        operator._credentials.jdbc_uri
+        == "jdbc:snowflake://account.snowflakecomputing.com/"
+        "?warehouse=COMPUTE_WH&db=ANALYTICS&schema=PUBLIC&role=ANALYST"
+    )
+    assert operator._parameters() == {
+        "user": "snowflake_user",
+        "password": "snowflake_password",
+    }
+
+
+def test_snowflake_legacy_key_file_uses_base64_private_key_parameter(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("JDBC_URI", raising=False)
+    monkeypatch.delenv("JDBC_CONNECTION_PARAMETERS", raising=False)
+    _clear_snowflake_env(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    tmp_path.joinpath("rsa_key.p8").write_bytes(b"private-key-pem")
+    monkeypatch.setenv("SNOWFLAKE_USER", "snowflake_user")
+    monkeypatch.setenv("SNOWFLAKE_KEY_PATH", "rsa_key.p8")
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "account")
+    monkeypatch.setenv("SNOWFLAKE_WAREHOUSE", "COMPUTE_WH")
+    monkeypatch.setenv("SNOWFLAKE_DATABASE", "ANALYTICS")
+    monkeypatch.setenv("SNOWFLAKE_SCHEMA", "PUBLIC")
+    monkeypatch.setenv("SNOWFLAKE_ROLE", "ANALYST")
+
+    operator = get_database_operator(AppInfra(llm="llm", database="snowflake"))
+
+    assert operator._parameters() == {
+        "user": "snowflake_user",
+        "private_key_base64": "cHJpdmF0ZS1rZXktcGVt",
+    }
+
+
+def test_snowflake_legacy_env_does_not_hide_invalid_explicit_jdbc_uri(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JDBC_URI", "jdbc:oracle://example.test/db")
+    monkeypatch.delenv("JDBC_CONNECTION_PARAMETERS", raising=False)
+    _clear_snowflake_env(monkeypatch)
+    monkeypatch.setenv("SNOWFLAKE_USER", "snowflake_user")
+    monkeypatch.setenv("SNOWFLAKE_PASSWORD", "snowflake_password")
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "account")
+    monkeypatch.setenv("SNOWFLAKE_WAREHOUSE", "COMPUTE_WH")
+    monkeypatch.setenv("SNOWFLAKE_DATABASE", "ANALYTICS")
+    monkeypatch.setenv("SNOWFLAKE_SCHEMA", "PUBLIC")
+    monkeypatch.setenv("SNOWFLAKE_ROLE", "ANALYST")
+
+    with pytest.raises(ValueError, match="JDBC_URI"):
+        get_database_operator(AppInfra(llm="llm", database="snowflake"))
 
 
 def test_jdbc_preview_get_schemas_uses_data_preview(

--- a/customize_docs/snowflake_jdbc_preview_configuration_20260713.md
+++ b/customize_docs/snowflake_jdbc_preview_configuration_20260713.md
@@ -1,0 +1,45 @@
+# Snowflake JDBC Preview configuration
+
+## 背景
+
+2026-07-13 時点の database 接続経路は upstream v11.10.1 に合わせ、`snowflake` / `sap` / `bigquery` / `datarobot_jdbc` を DataRobot JDBC Preview 経路へ統一している。
+
+## 仕様
+
+- `DATABASE_CONNECTION_TYPE=snowflake` を選んだ場合でも、実行時は `JdbcPreviewOperator` を使う。
+- 標準経路では `JDBC_URI` に接続先、warehouse、database、schema、role などを含め、必要に応じて `JDBC_CONNECTION_PARAMETERS` に user/password または key 認証情報を渡す。
+- 互換経路として、`DATABASE_CONNECTION_TYPE=snowflake` かつ `JDBC_URI` が未設定の場合だけ、`SNOWFLAKE_ACCOUNT` / `SNOWFLAKE_WAREHOUSE` / `SNOWFLAKE_DATABASE` / `SNOWFLAKE_SCHEMA` / `SNOWFLAKE_ROLE` などの旧 Snowflake 専用変数から Snowflake JDBC 設定へ変換する。
+- `SNOWFLAKE_KEY_PATH` は DataRobot JDBC Preview へ `private_key_file` として渡さない。DataRobot 側からローカルファイルパスを読めないため、デプロイ時に PEM ファイル内容を `private_key_base64` へ変換する。
+- 明示的に `JDBC_URI` が設定されている場合は、その値を優先する。不正な `JDBC_URI` が設定されていても旧 Snowflake 変数へ fallback しない。
+- 変換ロジックは upstream 差分として追いやすいように `core/src/core/customize/snowflake_jdbc_compat.py` に集約する。
+
+## 例
+
+```env
+DATABASE_CONNECTION_TYPE=snowflake
+JDBC_URI=jdbc:snowflake://<account_identifier>.snowflakecomputing.com/?warehouse=COMPUTE_WH&db=SNOWFLAKE_SAMPLE_DATA&schema=TPCH_SF1&role=PUBLIC
+JDBC_CONNECTION_PARAMETERS='{"user": "snowflake_user", "password": "snowflake_password"}'
+```
+
+## テスト
+
+- `core/tests/test_v1182_core.py::test_snowflake_legacy_env_values_build_jdbc_preview_operator`
+  - 旧 `SNOWFLAKE_*` 変数から Snowflake JDBC Preview 設定を組み立てることを固定する。
+- `core/tests/test_v1182_core.py::test_snowflake_legacy_key_file_uses_base64_private_key_parameter`
+  - `SNOWFLAKE_KEY_PATH` を `private_key_file` ではなく `private_key_base64` に変換することを固定する。
+- `core/tests/test_v1182_core.py::test_snowflake_legacy_env_does_not_hide_invalid_explicit_jdbc_uri`
+  - 明示された不正な `JDBC_URI` を旧 Snowflake 変数で隠さないことを固定する。
+
+## 2026-07-13 deployment error investigation
+
+添付ログでは Pulumi の `get_database_credentials("snowflake")` が `JdbcPreviewOperator.validate_connection()` を呼び、DataRobot JDBC Preview API で `400 client error: Invalid parameter value null for parameter type {1}` により失敗していた。
+
+原因は、旧 `SNOWFLAKE_KEY_PATH` を JDBC parameter の `private_key_file` として渡していたこと。DataRobot JDBC Preview は DataRobot 側で JDBC を実行するため、ローカルの `rsa_key.p8` パスを読めない。
+
+実接続検証では以下の結果だった。
+
+- `private_key_file=<local path>`: 同じ `Invalid parameter value null...` で失敗
+- `private_key_base64=<DER bytes base64>`: `Private key provided is invalid...` で失敗
+- `private_key_base64=<PEM file bytes base64>`: `SELECT 1` に成功
+
+このため、互換変換では PEM ファイル内容を base64 化して `private_key_base64` に渡す。

--- a/customize_docs/test_v11_10_2_integration.py
+++ b/customize_docs/test_v11_10_2_integration.py
@@ -109,6 +109,8 @@ def test_env_template_documents_snowflake_values() -> None:
     )
     assert "SNOWFLAKE_SAMPLE_DATA" in env_template
     assert "TPCH_SF1" in env_template
+    assert "private_key_base64" in env_template
+    assert "Local private_key_file paths are not readable" in env_template
     for expected in (
         'snowflake_authentication="key file authentication"',
         'SNOWFLAKE_USER="<snowflake_user>"',

--- a/infra/infra/app_backend.py
+++ b/infra/infra/app_backend.py
@@ -380,7 +380,6 @@ app_backend_app_source = datarobot.ApplicationSource(
         resource_label=CustomAppResourceBundles.CPU_7XL.value.id,
         replicas=1,
         service_web_requests_on_root_path=True,
-        session_affinity=True,
     ),
     required_key_scope_level=required_key_scope_level,
     opts=pulumi.ResourceOptions(retain_on_delete=True),

--- a/infra/infra/components/dr_credential.py
+++ b/infra/infra/components/dr_credential.py
@@ -26,6 +26,9 @@ from core.credentials import (  # type: ignore[import-not-found]
     JDBCCredentials,
     NoDatabaseCredentials,
 )
+from core.customize.snowflake_jdbc_compat import (  # type: ignore[import-not-found]
+    snowflake_jdbc_credentials_from_legacy_env,
+)
 from core.schema import (  # type: ignore[import-not-found]
     DatabaseConnectionType,
 )
@@ -129,8 +132,14 @@ def get_database_credentials(
         if database == "no_database":
             return NoDatabaseCredentials()
 
-        if database in ("snowflake", "bigquery", "sap", "datarobot_jdbc"):
+        if database == "snowflake":
+            credentials = snowflake_jdbc_credentials_from_legacy_env()
+            if credentials is None:
+                credentials = JDBCCredentials()  # type: ignore[call-arg]
+        elif database in ("bigquery", "sap", "datarobot_jdbc"):
             credentials = JDBCCredentials()  # type: ignore[call-arg]
+
+        if database in ("snowflake", "bigquery", "sap", "datarobot_jdbc"):
             if test_credentials:
                 from core.data_connections.database.database_implementations import (  # type: ignore[import-not-found]
                     JdbcPreviewOperator,


### PR DESCRIPTION
## Summary
- Add a customize-scoped Snowflake JDBC compatibility helper for legacy `SNOWFLAKE_*` env vars.
- Convert `SNOWFLAKE_KEY_PATH` PEM files to `private_key_base64` for DataRobot JDBC Preview instead of passing local `private_key_file` paths.
- Wire the helper into runtime and Pulumi credential setup, and document the behavior in `.env.template` and customize docs.
- Remove `session_affinity=True` from the app backend source resources.

## Root Cause
DataRobot JDBC Preview runs remotely, so a local `private_key_file` path such as `rsa_key.p8` is not readable there. That produced the 400 `Invalid parameter value null` error during Pulumi credential validation.

## Validation
- `uv run --project core pytest core/tests/test_v1182_core.py -q`
- `uv run pytest app_backend/tests/test_v1182_compat.py customize_docs/test_v11_10_2_integration.py -q`
- `uv run pytest app_backend/tests/test_v1182_compat.py customize_docs/test_application_source_retention.py customize_docs/test_v11_10_2_integration.py -q`
- `uv run ruff check core/src/core/customize/snowflake_jdbc_compat.py core/src/core/database_helpers.py infra/infra/components/dr_credential.py core/tests/test_v1182_core.py app_backend/tests/test_v1182_compat.py customize_docs/test_v11_10_2_integration.py`
- `uv run ruff check infra/infra/app_backend.py app_backend/tests/test_v1182_compat.py customize_docs/test_application_source_retention.py customize_docs/test_v11_10_2_integration.py`
- `uv run ruff format --check core/src/core/customize/snowflake_jdbc_compat.py core/src/core/database_helpers.py infra/infra/components/dr_credential.py core/tests/test_v1182_core.py app_backend/tests/test_v1182_compat.py customize_docs/test_v11_10_2_integration.py`
- Direct `get_database_credentials("snowflake", test_credentials=True)` check against DataRobot JDBC Preview succeeded with local `.env`.