### PR TITLE
Harden Snowflake JDBC SQL prompt

### DIFF
--- a/core/src/core/customize/prompts.py
+++ b/core/src/core/customize/prompts.py
@@ -29,7 +29,11 @@ Your query should return not just the facts directly related to the question, bu
 Your query will be executed from Python using the Snowflake Python Connector.
 
 RESPONSE:
-Your response shall be a single, executable Snowflake SQL query that retrieves, analyzes, aggregates and returns the information required to answer the user's question.
+Your response shall be a JSON object with the following fields:
+1) code: one executable Snowflake SQL query that retrieves, analyzes, aggregates and returns the information required to answer the user's question.
+2) description: a brief explanation of how the code works and how to interpret its results.
+Return valid JSON only. Do not wrap the JSON or SQL in Markdown code fences.
+The code value must contain SQL only. Do not include prose, labels, or non-SQL text in it.
 In addition, your response should return any relevant, supporting or contextual information to help the user better understand the results.
 Try to ensure that your query does not return an empty result set.
 Your code may not include any operations that could alter or corrupt the data in Snowflake.
@@ -40,13 +44,6 @@ The result of this query will be analyzed by humans and plotted in charts, so co
 Do not provide multiple queries that must be executed in different steps - the query must execute in a single step.
 Do not include any USE statements.
 Include comments to explain your code.
-Your response shall be formatted as JSON with the following fields:
-1) code: Snowflake SQL code that will execute and return the data
-2) description: A brief description of how the code works, and how the results can be interpreted to answer the question.
-
-SNOWFLAKE ENVIRONMENT:
-Warehouse: {warehouse}
-Database: {database}
 
 NECESSARY CONSIDERATIONS:
 Carefully consider the metadata and the sample data when constructing your query to avoid errors or an empty result.
@@ -54,13 +51,23 @@ For example, seemingly numeric columns might contain non-numeric formatting such
 When performing date operations on a date column, consider casting that column as a DATE for error redundancy.
 To ensure case sensitivity of column names, use quotes around column names.
 This query will be executed using the Snowflake Python Connector. Make sure the query will be compatible with the Snowflake Python Connector.
-Always reference tables fully quoted and qualified, as in '{database}."SCHEMA_NAME"."TABLE_NAME"' and quote any column names in the query.
+Always quote table and column identifiers in the query.
+
+JDBC EXECUTION CONSTRAINTS:
+The code value is embedded inside a derived table by the JDBC execution service. It MUST contain exactly one SELECT statement or one WITH/CTE statement that ends in a SELECT statement, and it MUST NOT have a trailing semicolon.
+Do not use SHOW, DESCRIBE, EXPLAIN, CALL, EXECUTE IMMEDIATE, SET, BEGIN/END, temporary objects, or session-dependent statements.
+Never use placeholders, template variables, or inferred database/schema names. Do not emit any database or schema token enclosed in single or double curly braces.
+Use only the exact table references provided in the sample data and data dictionary. Do not invent, substitute, or prepend a database or schema name.
+For ordered Snowflake ARRAY_AGG expressions, use exactly this form:
+ARRAY_AGG(DISTINCT expression) WITHIN GROUP (ORDER BY expression)
+When ARRAY_AGG uses DISTINCT and WITHIN GROUP, the ORDER BY expression must be the same expression passed to ARRAY_AGG.
 
 
 REATTEMPT:
 It's possible that your query will fail due to a SQL error or return an empty result set.
 If this happens, you will be provided the failed query and the error message.
 Take this failed SQL code and error message into consideration when building your query so that the problem doesn't happen again.
+Correct the reported syntax or identifier issue. Do not repeat an invalid placeholder, table reference, or aggregate ordering pattern from the failed query.
 
 Remember that snowflake is case sensitive, and assumes ANY unquoted identifier are UPPER_CASE. Quote everything!
 """

--- a/core/tests/test_v1182_core.py
+++ b/core/tests/test_v1182_core.py
@@ -182,6 +182,34 @@ def test_jdbc_preview_query_name_supports_schema_prefixed_dataset_name(
     assert operator.query_friendly_name("SALES.orders") == '"SALES"."orders"'
 
 
+def test_snowflake_jdbc_system_prompt_requires_derived_table_safe_sql(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "JDBC_URI",
+        "jdbc:snowflake://account.snowflakecomputing.com/?db=ANALYTICS&schema=PUBLIC",
+    )
+
+    prompt = JdbcPreviewOperator(JDBCCredentials()).get_system_prompt()["content"]
+
+    assert "exactly one SELECT statement or one WITH/CTE statement" in prompt
+    assert "MUST NOT have a trailing semicolon" in prompt
+    assert "Return valid JSON only" in prompt
+    assert "Do not wrap the JSON or SQL in Markdown code fences" in prompt
+    assert "Do not use SHOW, DESCRIBE, EXPLAIN, CALL" in prompt
+    assert "Never use placeholders, template variables" in prompt
+    assert "Use only the exact table references" in prompt
+    assert (
+        "ARRAY_AGG(DISTINCT expression) WITHIN GROUP (ORDER BY expression)" in prompt
+    )
+    assert "ORDER BY expression must be the same expression" in prompt
+    assert "Do not repeat an invalid placeholder, table reference" in prompt
+    assert "Warehouse: {warehouse}" not in prompt
+    assert "Database: {database}" not in prompt
+    assert "{database}" not in prompt
+    assert "{schema}" not in prompt
+
+
 @pytest.mark.parametrize(
     ("database", "jdbc_uri", "quoted_name"),
     [

--- a/customize_docs/snowflake_jdbc_sql_prompt_20260715.md
+++ b/customize_docs/snowflake_jdbc_sql_prompt_20260715.md
@@ -1,0 +1,25 @@
+# Snowflake JDBC SQL prompt constraints
+
+## 変更内容
+
+DataRobot JDBC Preview は生成SQLを派生テーブルとして実行する。そのため、Snowflake のSQL生成に使用される `core/src/core/customize/prompts.py` の `SYSTEM_PROMPT_SNOWFLAKE` を更新した。
+
+- `code` は末尾セミコロンなしの単一 `SELECT` または `WITH`/CTE + `SELECT` に限定する。
+- データベース名・スキーマ名を含むプレースホルダーやテンプレート変数を禁止する。
+- サンプルデータおよびデータディクショナリーで提供された完全一致のテーブル参照だけを使用する。
+- 順序付き `ARRAY_AGG` は `ARRAY_AGG(DISTINCT expression) WITHIN GROUP (ORDER BY expression)` に限定する。
+- LLMの応答はJSONのみとし、Markdownコードフェンスおよび `code` 内の非SQLテキストを禁止する。
+- JDBC派生テーブルで実行できないセッション依存文（`SHOW`、`DESCRIBE`、`EXPLAIN`、`CALL`、`SET`など）を禁止する。
+- `ARRAY_AGG` で `DISTINCT` と `WITHIN GROUP` を併用する場合、集約対象と順序式を同一にする。
+- リトライ時は、直前の構文・識別子・プレースホルダー・集約順序の失敗パターンを繰り返さない。
+
+旧来の `Warehouse: {warehouse}` / `Database: {database}` は JDBC の `get_system_prompt()` では展開されず、生成SQLに混入する可能性があるため削除した。
+
+## テスト
+
+- `core/tests/test_v1182_core.py::test_snowflake_jdbc_system_prompt_requires_derived_table_safe_sql`
+  - JDBC Snowflake operator が実際に返すシステムプロンプトに、JSON出力・JDBC実行・`ARRAY_AGG`・リトライの全制約が存在すること、未展開の環境プレースホルダーがないことを検証する。
+
+## 構文確認
+
+Snowflake公式ドキュメントにより、`ARRAY_AGG` の並び順指定には `WITHIN GROUP` を使う構成を確認した。


### PR DESCRIPTION
## Summary

- Add JDBC-derived-table-safe Snowflake SQL constraints to the active system prompt.
- Remove unresolved warehouse/database placeholders from the JDBC prompt path.
- Add a prompt contract test and document the behavior.

## Root cause

The JDBC preview service embeds generated SQL in a derived table. The active prompt did not prohibit trailing semicolons or unresolved placeholders, and it did not require Snowflake-compatible ordered `ARRAY_AGG` syntax.

## Validation

- `uv run --project . pytest tests/test_v1182_core.py -q` (25 passed)

## Impact

Generated Snowflake SQL is constrained to a single derived-table-safe SELECT/CTE statement and avoids the prior placeholder and ordered aggregation failure modes.
