### PR TITLE
Restore Pulumi monitoring resource management

### DIFF
--- a/.github/workflows/pulumi-up.yml
+++ b/.github/workflows/pulumi-up.yml
@@ -44,8 +44,6 @@ jobs:
       APPLICATION_EXECUTION_ENVIRONMENT_VERSION_ID: ${{ github.ref == 'refs/heads/main' && secrets.APPLICATION_EXECUTION_ENVIRONMENT_VERSION_ID
         || '' }}
       SKIP_PULUMI_FRONTEND_BUILD: "true"
-      SKIP_PULUMI_CUSTOM_JOBS: "true"
-      DISALLOW_MONITORING_RESOURCES: "true"
       VITE_ENABLE_TEMPLATE_EDIT: ${{ secrets.VITE_ENABLE_TEMPLATE_EDIT }}
       VITE_ENABLE_CUSTOM_PROMPTS: ${{ secrets.VITE_ENABLE_CUSTOM_PROMPTS }}
       PROMPTS_TEMPLATE_PATH: ${{ secrets.PROMPTS_TEMPLATE_PATH }}
@@ -130,13 +128,7 @@ jobs:
             custom:resource:CustomJobPostActions \
             custom:resource:CustomJobScheduleCleanup \
             command:local:Command \
-            datarobot:index/customJob:CustomJob \
-            datarobot:index:CustomJob \
             --resource-name "Data Analyst App Source [$project_name]" \
-            --resource-name "Data Analyst Dashboard Source [$project_name]" \
-            --resource-name "Data Analyst Dashboard [$project_name]" \
-            --resource-name "Dataset Trace [$project_name]" \
-            --resource-name "Dataset Access Log [$project_name]" \
             > /tmp/pruned-urns.txt
 
           stale_urns="$(cat /tmp/pruned-urns.txt)"

--- a/customize_docs/pulumi_frontend_build.md
+++ b/customize_docs/pulumi_frontend_build.md
@@ -26,15 +26,16 @@ cleanup 時に `pulumi-resource-command` process が残っていた。
   stack export JSON から prune し、`pulumi stack import` で反映する。
   - 失敗した replacement が複数残ると同一 URN が曖昧になり、`pulumi state delete`
     では削除できないため。
-- CI では `SKIP_PULUMI_CUSTOM_JOBS=true` も設定し、`pulumi-datarobot` provider の
-  CustomJob 更新を避ける。
-  - command resource を外した後も `datarobot:index:CustomJob Usage Export Job`
-    の更新完了直後に update が終了しないため。
-  - 既存 DataRobot CustomJob は削除せず、Pulumi state からのみ prune する。
-- CI では `DISALLOW_MONITORING_RESOURCES=true` も設定し、usage dashboard と
-  monitoring datasets も Pulumi state からのみ prune する。
-  - CustomJob を外した後も `Data Analyst Dashboard [dev]` の更新が完了せず、
-    update が終了しないため。
+- 2026-07-24、CI の `SKIP_PULUMI_CUSTOM_JOBS=true` と
+  `DISALLOW_MONITORING_RESOURCES=true` を削除し、Usage Export Job、usage dashboard、
+  Trace Dataset、Access Log Dataset をPulumi管理へ戻した。
+  - 監視リソースをstateから除外したまま物理Custom Jobだけを残すと、Datasetが削除・
+    置換された後もJobのruntime parameterが古いDataset IDを参照し、実行時に
+    DataRobot APIの `410 GONE` となるため。
+  - CIのstate prune対象からCustom Job、usage dashboard、monitoring datasetsを外し、
+    `pulumi refresh` と `pulumi up` で実リソースとstateを継続的に同期する。
+  - 過去のschedule管理用ComponentResourceは物理リソースを持たないため、従来どおり
+    prune対象に残す。
 - CI では main app の `Data Analyst App Source` も Pulumi state から prune する。
   - `ApplicationSource` / `CustomApplication` 更新後に旧 source を delete original
     しようとして、DataRobot API が 422 `This entity is in use by a custom application`
@@ -49,10 +50,11 @@ cleanup 時に `pulumi-resource-command` process が残っていた。
   - Pulumi stack が事前 build 済み frontend assets を直接使えることを確認する。
 - `customize_docs/test_pulumi_workflow_refresh.py`
   - workflow が `command:local:Command` state を事前 prune することを確認する。
-  - workflow が branch に対応した resource name で App Source / monitoring state を
-    事前 prune することを確認する。
+  - workflow が branch に対応したApp Sourceだけを事前pruneすることを確認する。
   - Pulumi action に `SKIP_PULUMI_FRONTEND_BUILD=true` が渡ることを確認する。
   - frontend assets build で `npm install` と fetch retry が設定されることを確認する。
   - git 管理されていない `package-lock.json` に依存する npm cache 設定を入れないことを確認する。
+  - Usage Export Job、usage dashboard、monitoring datasetsをCIがskipまたはstate prune
+    しないことを確認する。
 - `customize_docs/test_prune_pulumi_state_resources.py`
   - stack export から対象 type の resources と、その依存参照を削除することを確認する。

--- a/customize_docs/test_pulumi_workflow_refresh.py
+++ b/customize_docs/test_pulumi_workflow_refresh.py
@@ -113,6 +113,21 @@ def test_pulumi_up_workflow_deploys_from_split_infra_project() -> None:
     }
 
 
+def test_pulumi_up_workflow_keeps_monitoring_resources_managed() -> None:
+    workflow = _load_workflow("pulumi-up.yml")
+    job = workflow["jobs"]["update"]
+    prune_step = _step_by_name(job["steps"], "Remove stale Pulumi state resources")
+
+    assert "SKIP_PULUMI_CUSTOM_JOBS" not in job["env"]
+    assert "DISALLOW_MONITORING_RESOURCES" not in job["env"]
+    assert "datarobot:index/customJob:CustomJob" not in prune_step["run"]
+    assert "datarobot:index:CustomJob" not in prune_step["run"]
+    assert 'Data Analyst Dashboard Source [$project_name]' not in prune_step["run"]
+    assert 'Data Analyst Dashboard [$project_name]' not in prune_step["run"]
+    assert 'Dataset Trace [$project_name]' not in prune_step["run"]
+    assert 'Dataset Access Log [$project_name]' not in prune_step["run"]
+
+
 def test_infra_python_workflow_runs_split_infra_checks() -> None:
     workflow = _load_workflow("infra-python.yml")
     job = workflow["jobs"]["python-checks"]


### PR DESCRIPTION
## Summary

- stop setting `SKIP_PULUMI_CUSTOM_JOBS` and `DISALLOW_MONITORING_RESOURCES` in the Pulumi CD workflow
- keep Usage Export Job, usage dashboard, Trace Dataset, and Access Log Dataset in Pulumi state
- add a regression test that prevents the workflow from pruning or skipping monitoring resources
- document the `410 GONE` root cause and the updated lifecycle policy

## Root cause

The CD workflow removed monitoring datasets and the Custom Job from Pulumi state while leaving the physical Custom Job in DataRobot. When its datasets were later deleted or replaced, the unmanaged job retained stale dataset IDs and failed with `410 GONE`.

## Validation

- `uv run pytest -q customize_docs/test_pulumi_workflow_refresh.py customize_docs/test_pulumi_monitoring_skip.py customize_docs/test_pulumi_custom_job_skip.py customize_docs/test_custom_job_schedule_resource.py customize_docs/test_prune_pulumi_state_resources.py customize_docs/test_infra_jobs_configuration.py` — 14 passed
- workflow YAML parse — passed
- `git diff --check` — passed

## Rollout considerations

The first Pulumi run after merge will recreate monitoring resources that are no longer present in stack state. The existing orphaned Custom Job is not deleted by this PR; verify after deployment that the newly managed job runtime parameters reference the newly managed dataset IDs.
