### PR TITLE
Fix dashboard unexpected finish chart

### DIFF
--- a/customize_docs/dashboard_unexpected_finish_keyerror_20260724.md
+++ b/customize_docs/dashboard_unexpected_finish_keyerror_20260724.md
@@ -1,0 +1,28 @@
+# Dashboard Unexpected Finish KeyError
+
+## 事象
+
+Usage DashboardのUnexpected Finish Trend描画時に、次の例外でStreamlitアプリの
+実行が停止し、後続のワードクラウドが表示されなかった。
+
+```text
+KeyError: False
+```
+
+`filtered["stopUnexpected"] is True` はpandas Seriesの要素比較ではなく、Series
+オブジェクト自体と `True` の同一性比較になる。その結果は常に単一の `False` となり、
+DataFrameが列名 `False` を参照していた。
+
+## 変更内容
+
+- `Series.eq(True)` で `stopUnexpected` を要素単位に比較し、該当行だけを集計する。
+- Streamlit 1.54で非推奨となった `use_container_width=True` を、Plotlyチャートと
+  詳細ログテーブルの全9箇所で `width="stretch"` に置き換える。
+
+## テスト
+
+`customize_docs/test_app_usage_dashboard_visualizations.py` で次を確認する。
+
+- `stopUnexpected` のTrue/Falseが混在するデータを日別に正しく集計できる。
+- Dashboardに `use_container_width` が残っておらず、9箇所すべてが
+  `width="stretch"` を使用する。

--- a/customize_docs/test_app_usage_dashboard_visualizations.py
+++ b/customize_docs/test_app_usage_dashboard_visualizations.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+import types
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).parents[1]
+DASHBOARD_DIR = REPO_ROOT / "resources" / "app_usage_dashboard"
+APP_SOURCE = DASHBOARD_DIR / "app.py"
+VISUALIZATIONS_SOURCE = DASHBOARD_DIR / "visualizations.py"
+
+
+def _load_visualizations(monkeypatch):
+    streamlit = types.ModuleType("streamlit")
+    streamlit_logger = types.ModuleType("streamlit.logger")
+    streamlit_logger.get_logger = logging.getLogger
+    wordcloud = types.ModuleType("wordcloud")
+    wordcloud.WordCloud = object
+    i18n_setup = types.ModuleType("i18n_setup")
+    i18n_setup._ = lambda key, **kwargs: key
+
+    monkeypatch.setitem(sys.modules, "streamlit", streamlit)
+    monkeypatch.setitem(sys.modules, "streamlit.logger", streamlit_logger)
+    monkeypatch.setitem(sys.modules, "wordcloud", wordcloud)
+    monkeypatch.setitem(sys.modules, "i18n_setup", i18n_setup)
+
+    spec = importlib.util.spec_from_file_location(
+        "app_usage_dashboard_visualizations",
+        VISUALIZATIONS_SOURCE,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_unexpected_finish_trend_counts_true_rows_by_period(monkeypatch) -> None:
+    visualizations = _load_visualizations(monkeypatch)
+    trace_chat = pd.DataFrame(
+        {
+            "date": [date(2026, 7, 23), date(2026, 7, 23), date(2026, 7, 24)],
+            "stopUnexpected": [True, False, True],
+        }
+    )
+
+    figure = visualizations.plot_unexpected_finish_trend(
+        trace_chat,
+        (date(2026, 7, 23), date(2026, 7, 24)),
+        "D",
+    )
+
+    assert list(figure.data[0].y) == [1, 1]
+
+
+def test_dashboard_uses_streamlit_width_parameter() -> None:
+    app_source = APP_SOURCE.read_text()
+
+    assert "use_container_width=" not in app_source
+    assert app_source.count('width="stretch"') == 9

--- a/resources/app_usage_dashboard/app.py
+++ b/resources/app_usage_dashboard/app.py
@@ -338,7 +338,7 @@ st.subheader(_("section_titles.active_user_trend"))
 fig = visualizations.plot_active_user_trend(
     filtered_df, (start, end), granularity[0].upper()
 )
-st.plotly_chart(fig, use_container_width=True, key="active_user_trend_chart")
+st.plotly_chart(fig, width="stretch", key="active_user_trend_chart")
 
 # Add download button below the chart
 trend_data = visualizations.get_active_user_trend_data(
@@ -360,7 +360,7 @@ st.subheader(_("section_titles.number_of_chats_trend"))
 fig2 = visualizations.plot_number_of_chats_trend(
     filtered_df, (start, end), granularity[0].upper()
 )
-st.plotly_chart(fig2, use_container_width=True, key="number_of_chats_trend_chart")
+st.plotly_chart(fig2, width="stretch", key="number_of_chats_trend_chart")
 
 # Add download button below the chart
 chats_trend_data = visualizations.get_number_of_chats_trend_data(
@@ -382,7 +382,7 @@ st.subheader(_("section_titles.user_activity_heatmap"))
 fig3 = visualizations.plot_user_activity_heatmap(
     filtered_df, (start, end), granularity[0].upper()
 )
-st.plotly_chart(fig3, use_container_width=True, key="user_activity_heatmap_chart")
+st.plotly_chart(fig3, width="stretch", key="user_activity_heatmap_chart")
 
 # Add download button below the chart
 heatmap_data = visualizations.get_user_activity_heatmap_data(
@@ -404,35 +404,35 @@ st.subheader(_("section_titles.llm_call_count_trend"))
 fig4 = visualizations.plot_llm_call_count_trend(
     filtered_df, (start, end), granularity[0].upper()
 )
-st.plotly_chart(fig4, use_container_width=True, key="llm_call_count_trend_chart")
+st.plotly_chart(fig4, width="stretch", key="llm_call_count_trend_chart")
 
 # Display LLM Error Count Trend chart
 st.subheader(_("section_titles.llm_error_avg_trend"))
 fig5 = visualizations.plot_llm_error_avg_trend(
     filtered_df, (start, end), granularity[0].upper()
 )
-st.plotly_chart(fig5, use_container_width=True, key="llm_error_avg_trend_chart")
+st.plotly_chart(fig5, width="stretch", key="llm_error_avg_trend_chart")
 
 # Display Average LLM Call Process Time Trend chart
 st.subheader(_("section_titles.llm_avg_process_time_trend"))
 fig6 = visualizations.plot_llm_avg_process_time_trend(
     filtered_df, (start, end), granularity[0].upper()
 )
-st.plotly_chart(fig6, use_container_width=True, key="llm_avg_process_time_trend_chart")
+st.plotly_chart(fig6, width="stretch", key="llm_avg_process_time_trend_chart")
 
 # Display Data Source Usage Trend chart
 st.subheader(_("section_titles.data_source_usage_trend"))
 fig7 = visualizations.plot_data_source_usage_trend(
     filtered_df, (start, end), granularity[0].upper()
 )
-st.plotly_chart(fig7, use_container_width=True, key="data_source_usage_trend_chart")
+st.plotly_chart(fig7, width="stretch", key="data_source_usage_trend_chart")
 
 # Display Unexpected Finish Trend chart
 st.subheader(_("section_titles.unexpected_finish_trend"))
 fig8 = visualizations.plot_unexpected_finish_trend(
     filtered_df, (start, end), granularity[0].upper()
 )
-st.plotly_chart(fig8, use_container_width=True, key="unexpected_finish_trend_chart")
+st.plotly_chart(fig8, width="stretch", key="unexpected_finish_trend_chart")
 
 # Display User Message Word Cloud
 st.subheader(_("section_titles.user_message_wordcloud"))
@@ -486,4 +486,4 @@ else:
     col_headers = [_(f"dataframe_headers.{col}") for col in display_cols]
     table_df = filtered_df[display_cols].copy()
     table_df.columns = col_headers
-    st.dataframe(table_df, use_container_width=True)
+    st.dataframe(table_df, width="stretch")

--- a/resources/app_usage_dashboard/visualizations.py
+++ b/resources/app_usage_dashboard/visualizations.py
@@ -347,7 +347,7 @@ def plot_unexpected_finish_trend(
         pd.to_datetime(filtered["date"]).dt.to_period(granularity).dt.to_timestamp()
     )
     data = (
-        filtered[filtered["stopUnexpected"] is True]
+        filtered.loc[filtered["stopUnexpected"].eq(True)]
         .groupby("period")
         .size()
         .reset_index(name="unexpected_count")


### PR DESCRIPTION
## Summary

- fix the Unexpected Finish Trend boolean filter that raised `KeyError: False`
- replace deprecated Streamlit `use_container_width=True` arguments with `width="stretch"`
- add a behavioral regression test for mixed `stopUnexpected` values
- document the production failure and validation

## Root cause

`filtered["stopUnexpected"] is True` compares the pandas Series object itself with `True`. The expression evaluates to the scalar `False`, so pandas attempts to select a column named `False` and raises `KeyError`.

The filter now uses `Series.eq(True)` to perform an element-wise comparison before grouping.

## User impact

The Dashboard no longer stops at Unexpected Finish Trend, so the following word clouds and detailed chat log can render. Streamlit 1.54 no longer emits the `use_container_width` deprecation warning for these charts and the table.

## Validation

- `uv run pytest -q customize_docs/test_app_usage_dashboard_visualizations.py` — 2 passed
- `uv run ruff check ...` — passed
- `uv run ruff format --check ...` — passed
- `python3 -m compileall -q resources/app_usage_dashboard` — passed
- loaded the function with `resources/app_usage_dashboard/requirements.txt` and confirmed counts `[1, 1]`
- `git diff --check` — passed
